### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vperezma @ryekerjh
+* @vperezma @ryekerjh @mwallert @coreyshuman @jantspo


### PR DESCRIPTION
add John Sposato, Corey Shuman and Micheal Wallert as default reviewers for PR's