### PR TITLE
feat(templates): Add PR and issue template for org

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+_This goes in your project's root directory under `.github/`_
+## Expected Behavior/Desired Use Case
+_If this is a bug, report what **should** be happening. If it's a feature, describe what this **should** implement._
+
+## Actual/Current Behavior
+_Describe what is currently happening._
+
+
+## Steps to Reproduce the Problem/Implement this feature
+  1.
+  2.
+  3.
+
+## Pre-Testing TODOs
+_What neeeds to be done before testing_
+1. Change DB values in x collection to y.
+
+## Testing Steps
+#### If you are not a member of this project, _skip this step_
+_How do the users test this change?_
+1. Navigate to x screen
+2. Click on y button
+3. Observe z result
+
+## Environment
+_If this is a bug, please provide **OS Version** and **Platform/Browser**, otherwise, delete this section_
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons that could be used to solve this problem_
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+_This goes in your project's root directory under `.github/` folder_
+## Changes
+_List Changes Introduced by this PR_
+1. Item 1
+2. Item 2
+
+## Purpose
+_Describe the problem or feature._
+
+## Approach
+_How does this change address the problem?_
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons used to solve this problem_
+
+Closes #
+
+
+

--- a/git-and-github/ISSUE_TEMPLATE.md
+++ b/git-and-github/ISSUE_TEMPLATE.md
@@ -11,5 +11,22 @@ _Describe what is currently happening._
   2.
   3.
 
-## Specifications
+## Pre-Testing TODOs
+_What neeeds to be done before testing_
+1. Change DB values in x collection to y.
+
+## Testing Steps
+#### If you are not a member of this project, _skip this step_
+_How do the users test this change?_
+1. Navigate to x screen
+2. Click on y button
+3. Observe z result
+
+## Environment
 _If this is a bug, please provide **OS Version** and **Platform/Browser**, otherwise, delete this section_
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons that could be used to solve this problem_
+

--- a/git-and-github/ISSUE_TEMPLATE.md
+++ b/git-and-github/ISSUE_TEMPLATE.md
@@ -1,3 +1,4 @@
+_This goes in your project's root directory under `.github/`_
 ## Expected Behavior/Desired Use Case
 _If this is a bug, report what **should** be happening. If it's a feature, describe what this **should** implement._
 

--- a/git-and-github/ISSUE_TEMPLATE.md
+++ b/git-and-github/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Expected Behavior/Desired Use Case
+_If this is a bug, report what **should** be happening. If it's a feature, describe what this **should** implement._
+
+## Actual/Current Behavior
+_Describe what is currently happening._
+
+
+## Steps to Reproduce the Problem/Implement this feature
+  1.
+  2.
+  3.
+
+## Specifications
+_If this is a bug, please provide **OS Version** and **Platform/Browser**, otherwise, delete this section_

--- a/git-and-github/PULL_REQUEST_TEMPLATE.md
+++ b/git-and-github/PULL_REQUEST_TEMPLATE.md
@@ -10,17 +10,6 @@ _Describe the problem or feature._
 ## Approach
 _How does this change address the problem?_
 
-## Pre-Testing TODOs
-_What neeeds to be done before testing_
-- [] Change DB values in x collection to y.
-
-## Testing Steps
-#### If you are not a member of this project, _skip this step_
-_How do the users test this change?_
-1. Navigate to x screen
-2. Click on y button
-3. Observe z result
-
 ## Learning
 _Describe the research stage_
 

--- a/git-and-github/PULL_REQUEST_TEMPLATE.md
+++ b/git-and-github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+
+## Changes
+_List Changes Introduced by this PR_
+1. Item 1
+2. Item 2
+
+## Purpose
+_Describe the problem or feature._
+
+## Approach
+_How does this change address the problem?_
+
+## Pre-Testing TODOs
+_What neeeds to be done before testing_
+- [] Change DB values in x collection to y.
+
+## Testing Steps
+_How do the users test this change?_
+1. Navigate to x screen
+2. Click on y button
+3. Observe z result
+
+## Learning
+_Describe the research stage_
+
+_Links to blog posts, patterns, libraries or addons used to solve this problem_
+
+Closes #
+
+
+

--- a/git-and-github/PULL_REQUEST_TEMPLATE.md
+++ b/git-and-github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-
+_This goes in your project's root directory under `.github/` folder_
 ## Changes
 _List Changes Introduced by this PR_
 1. Item 1
@@ -15,6 +15,7 @@ _What neeeds to be done before testing_
 - [] Change DB values in x collection to y.
 
 ## Testing Steps
+#### If you are not a member of this project, _skip this step_
 _How do the users test this change?_
 1. Navigate to x screen
 2. Click on y button

--- a/git-and-github/README.md
+++ b/git-and-github/README.md
@@ -7,3 +7,5 @@
 - [Commit Messages](commits.md) the Shift3/Karma way
 - [Setting up Projects](project-setup.md) in Github
 - [Readme Guidelines](/git-and-github/readme-guidelines.md) to document project
+- [Pull Request Template](/git-and-github/PULL_REQUEST_TEMPLATE.md)
+- [Issue Template](/git-and-github/ISSUE_TEMPLATE.md)


### PR DESCRIPTION

## Changes
1. Adds an issue template 
2. Adds a PR template

## Purpose
Ideally all of our repos from this point on (after presentation) will adopt the use of these templates to make our issue creation and PR summaries more succinct, verbose, and uniform across projects.

## Approach
By automating the process of scaffolding out the structure of the PR and Issue creation process, this will bring uniformity and more detail to both processes. 

## Pre-Testing TODOs
N/A

## Testing Steps
1. Check the templates to make sure I didn't miss any nice-to-haves

## Learning
I looked these up over the weekend and they're awesome! I linked to them in issue #113.

Closes #113 



