### PR TITLE
Update php:7.1-fpm to php:7.2-fpm and extensions

### DIFF
--- a/server-side/framework/php/laravel/docker/php-fpm/Dockerfile
+++ b/server-side/framework/php/laravel/docker/php-fpm/Dockerfile
@@ -1,13 +1,14 @@
-FROM php:7.1-fpm
+FROM php:7.2-fpm
 
 RUN apt-get update && apt-get install -y \
     curl \
     libssl-dev \
     zlib1g-dev \
     libicu-dev \
-    libmcrypt-dev
+    libmcrypt-dev \
+    libxml2-dev
 RUN docker-php-ext-configure intl
-RUN docker-php-ext-install pdo_mysql mbstring intl opcache mcrypt
+RUN docker-php-ext-install xml pdo pdo_mysql mbstring intl bcmath ctype json tokenizer
 
 # Install xdebug
 RUN pecl install xdebug \


### PR DESCRIPTION
## Changes
1. Update php:7.1-fpm to php:7.2-fpm
2. Update Extensions: BCMath, Ctype, JSON, Mbstring, PDO, Tokenizer, XML 

## Purpose
Change PHP docker settings for Laravel 6.0 requirements. 

## Potential Issues
Missing required extension "OpenSSL". Conflict for those needing Laravel 5.0 project

## Potential Fixes
Structure change to standard-and-practices framework 
