### PR TITLE
feat(presentations): Adds a readme for accessing the S&P slide decks

### DIFF
--- a/presentations/README.md
+++ b/presentations/README.md
@@ -1,6 +1,15 @@
 # S&P Presentations
+
+## Slide Decks
 Our intrepid developers have compiled a wealth of knowledge about the technology we work with and the way we use it. The spreadsheet below is a compilation of slide decks and videos (if available) of Standards and Practices presentations given. These are a great resource if you're looking for tips and tricks, or if you need to prepare yourself for technology you haven't used before!
 
 [Shift3 Technologies Slide Decks](https://docs.google.com/spreadsheets/d/1wlaAs7a4a0mDrMCMZeE7UI1gGeqv36yCw-hiR0e4TzU/edit?usp=sharing)
 
 **If you don't already have access to this (not a member of the Bitwise group on Google, for example), request access!**
+
+## Becoming a Presenter
+Experienced with a tool or technology that you think will benefit our combined efforts? We'd love to hear you talk about it! Each presenter is granted an hour to present their topic; you'll also want to make a deck of slides to aid your presentation. The presentation does not need to fill a full hour, but we do have our presentation room reserved for that hour. Use the Google Doc below to sign up.
+
+[Standards and Practices Sign Up Sheet](https://docs.google.com/document/d/1bXq6LmGhS2mvXPdxMuPk3tUxZLGKtYekf5ILH_IEN1M/edit?usp=sharing)
+
+We've already grown so much from the lessons given at these sessions, and you can be a part of it! Happy presenting!

--- a/presentations/README.md
+++ b/presentations/README.md
@@ -1,0 +1,6 @@
+# S&P Presentations
+Our intrepid developers have compiled a wealth of knowledge about the technology we work with and the way we use it. The spreadsheet below is a compilation of slide decks and videos (if available) of Standards and Practices presentations given. These are a great resource if you're looking for tips and tricks, or if you need to prepare yourself for technology you haven't used before!
+
+[Shift3 Technologies Slide Decks](https://docs.google.com/spreadsheets/d/1wlaAs7a4a0mDrMCMZeE7UI1gGeqv36yCw-hiR0e4TzU/edit?usp=sharing)
+
+**If you don't already have access to this (not a member of the Bitwise group on Google, for example), request access!**


### PR DESCRIPTION
## Changes
1. Adds a readme for accessing the S&P slide decks

## Purpose
The S&P slide deck link was only accessible to employees on the Bitwise Slack channel.

## Approach
Adds a new folder for information on presentations with a readme containing a link to the slide decks.



