### PR TITLE
docs(code review): Clarify testing and merging as part or review

### DIFF
--- a/git-and-github/code-reviews.md
+++ b/git-and-github/code-reviews.md
@@ -24,6 +24,7 @@
     - [ ] Use a linter (esLint is probably going to be the standard) to take care of whitespace and styling
     - [ ] Remove your console references and debuggers
     - [ ] Make sure your code changes are under 500 lines of code (break it up into more than 1 PR if it exceeds this)
+    - [ ] Your PR should be based from the development branch, and not from other open PRs. If you MUST have stair-stepped PRs for a valid reason, please include justification in the PR and reference to the PRs which this new PR depends on.
 
 2. Submit your pull request and tag potential reviewers. Keep in mind that each reviewer should: 
     * Be either on your project or a quick study on the stack your project is in

--- a/git-and-github/code-reviews.md
+++ b/git-and-github/code-reviews.md
@@ -58,7 +58,7 @@
     * `Approve`: If the code looks good and you have no questions/concerns, or if the author has submitted fixes to a blocking PR, mark it as approved.  
     * `Comment`: If you have comments/concerns but you are not blocking the author (no bugs) then mark the review as comment and leave your comments. Let the author know that they can merge if they don't want to address your concerns.
 
-3. If you are a maintainer for the project you can Squash & Merge or just Merge the PR and delete the compare branch once it is approved. If you are not a maintainer for the project, do NOT merge the PR. Leave it for the author or maintainers.
+3. If you are a maintainer for the project you can Squash & Merge or just Merge the PR and delete the compare branch once it is approved. If you are not a maintainer for the project, **DO NOT MERGE THE PR**. Leave it for the author or maintainers.
 
 ## Results
 We have already had lots of success catching errors and bugs, as well as teaching each other what we know and sharing that knowledge in a way that normally doesn't happen. If you have a success story you have experienced, please submit a PR to this .md doc with your experience so you can share it!

--- a/git-and-github/code-reviews.md
+++ b/git-and-github/code-reviews.md
@@ -30,7 +30,7 @@
     * Not always be the same person/people (mix it up!)
     * Understand the purpose of the PR
 
-3. Add comments when you create the PR that explain its scope, purpose, and any quirky things that you had to do to the code to make it work. Explain as much as possible in these comments to let the reviewer know about the PR.  
+3. Add comments when you create the PR that explain its scope, purpose, and any quirky things that you had to do to the code to make it work. Explain as much as possible in these comments to let the reviewer know about the PR. If you don't want it merged by a project maintainer, add a `DO NOT MERGE` label to the PR before it is reviewed.  
 
 4. If you receive a blocked review, fix up the issues and push the changes to your branch. Let the reviewer know when you have submitted the fix. Remember, we all make mistakes, and we all have room to grow. This is an opportunity to learn.
 
@@ -42,7 +42,7 @@
 
         * Limit your review time to half an hour (if the PR takes longer than that to review, suggest to the author that they break it up)
 
-        * Pull the code in and run it on your machine (if possible) to test it
+        * If you are part of the dev team for the project, your team may decide to have members pull code and test the app as part of the review. If you are not part of the dev team for the project, there is no requirement to actually test the code, just visually inspect it.
 
         * Don’t block the PR unless there is a legitimate bug
 
@@ -52,10 +52,12 @@
 
         * Don’t forget to compliment the submitter on good stuff, too!
 
-2. Mark your review as one of the following:
-    `Request Changes`: If there are bugs in the code or something unacceptable being introduced to the code base (swearing in comments, console references and debuggers, etc.), you should block the PR and leave detailed comments as to why. If you block a PR and the author resubmits changes, get to them as quickly as you can and approve the PR once it's addressed
-    `Approve`: If the code looks good and you have no questions/concerns, or if the author has submitted fixes to a blocking PR, mark it as approved and Squash & Merge or just Merge the PR and delete the compare branch.
-    `Comment`: If you have comments/concerns but you are not blocking the author (no bugs) then mark the review as comment and leave your comments. Let the author know that they can merge if they don't want to address your concerns.
+2. Mark your review as one of the following:  
+    * `Request Changes`: If there are bugs in the code or something unacceptable being introduced to the code base (swearing in comments, console references and debuggers, etc.), you should block the PR and leave detailed comments as to why. If you block a PR and the author resubmits changes, get to them as quickly as you can and approve the PR once it's addressed.  
+    * `Approve`: If the code looks good and you have no questions/concerns, or if the author has submitted fixes to a blocking PR, mark it as approved.  
+    * `Comment`: If you have comments/concerns but you are not blocking the author (no bugs) then mark the review as comment and leave your comments. Let the author know that they can merge if they don't want to address your concerns.
+
+3. If you are a maintainer for the project you can Squash & Merge or just Merge the PR and delete the compare branch once it is approved. If you are not a maintainer for the project, do NOT merge the PR. Leave it for the author or maintainers.
 
 ## Results
 We have already had lots of success catching errors and bugs, as well as teaching each other what we know and sharing that knowledge in a way that normally doesn't happen. If you have a success story you have experienced, please submit a PR to this .md doc with your experience so you can share it!


### PR DESCRIPTION
## Changes
1. Specify who should test code as part of PR review (dev team, not external teams)
1. Specify who should merge code after approval (project maintainers only)
1. Address stair-stepped PRs. In general we don't do them at Shift3.

## Purpose
We had a lot of confusion and a few frustrated devs over the last few months related to PR reviews. Addresses the following:
- External team members are not required to pull down and test code as part of a review.
- External team members should not merge code after a review. Only project maintainers should be merging PRs.
- In general we don't do stair-stepped PRs at Shift3. They require lots of pulling and merging by the reviewer to get through the stack of PRs. This would prevent us from easily having external team members review code for which they are unfamiliar with. This also causes PRs to stack up and become blocked when a dependent PR has requested changes.

