### PR TITLE
docs(framework): add official descriptions

### DIFF
--- a/best-practices/server-side/framework/README.md
+++ b/best-practices/server-side/framework/README.md
@@ -2,8 +2,8 @@
 
 ## This is a list of relevant frameworks separated by language that are modern, but also provide an education to further develop the skills of each developer
 
-- [Node](node/README.md) - [needs more info]
-- [Python](python/README.md) - [needs more info]
-- [Ruby](ruby/README.md) - [needs more info]
-- [.NET](dotnet/README.md) - [needs more info]
-- [PHP](php/README.md) - [needs more info]
+- [Node](node/README.md) - Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+- [Python](python/README.md) - Python is a programming language that lets you work quickly and integrate systems more effectively.
+- [Ruby](ruby/README.md) - A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write. 
+- [.NET](dotnet/README.md) - .NET is a free, cross-platform, open source developer platform for building many different types of applications.
+- [PHP](php/README.md) - PHP is a popular general-purpose scripting language that is especially suited to web development.


### PR DESCRIPTION
## Changes
Adds a little more detail to each described framework. 

## Approach
All five frameworks/languages have an official tag or description from their main websites. I just added those to the descriptions.

References #160



