### PR TITLE
feat(awesome-bot): check all available links

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:latest
+    steps:
+      - checkout
+      - run: gem install awesome_bot
+      - run: awesome_bot --allow-redirect `find . -name "*.md"`


### PR DESCRIPTION
## Changes
1. Adds CircleCI to the project.
2. Adds [awesome-bot](https://github.com/dkhamsing/awesome_bot) to the repo.

## Approach
The awesome bot gem is used to check all .md files recursively and report back if any of the links are incorrect via CircleCI. This will make sure all outside links are still relevant and prevents confusion to developers looking at non-existent links.

Closes #162 

One thing to note, a code owner or someone with access to CircleCI will have to add this project. I currently don't have access.



