### PR TITLE
feat(angular-circleci): Angular Circleci build and test

### DIFF
--- a/best-practices/client-side/framework/angular/README.md
+++ b/best-practices/client-side/framework/angular/README.md
@@ -1,3 +1,6 @@
 # angular
 
 ## this could be separated by version type in the future, how to spin up a boilerplate
+
+## CircleCI
+* Official Resource : https://angular.io/guide/testing#configure-project-for-circle-ci

--- a/best-practices/development-tools/continuous-integration/angular_config.yml
+++ b/best-practices/development-tools/continuous-integration/angular_config.yml
@@ -1,0 +1,16 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/angular-ci-example
+    docker:
+      - image: circleci/node:10-browsers
+    steps:
+      - checkout
+      - restore_cache:
+          key: my-project-{{ .Branch }}-{{ checksum "package-lock.json" }}
+      - run: npm install
+      - save_cache:
+          key: my-project-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          paths:
+            - "node_modules"
+      - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI

--- a/best-practices/development-tools/continuous-integration/angular_config.yml
+++ b/best-practices/development-tools/continuous-integration/angular_config.yml
@@ -1,7 +1,7 @@
 version: 2
 jobs:
   build:
-    working_directory: ~/angular-ci-example
+    working_directory: ~/my-project
     docker:
       - image: circleci/node:10-browsers
     steps:
@@ -14,3 +14,4 @@ jobs:
           paths:
             - "node_modules"
       - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI
+      - run: npm run e2e -- --protractor-config=e2e/protractor-ci.conf.js


### PR DESCRIPTION
## Changes
1. Add MVP Angular + CircleCI specific yml

## Approach
By adding a known good CircleCI configuration, developers will be able to add CircleCI specific builds and tests to their respective projects. This is the bare minimum to get started. I funny expect this to change in the near future.

## Learning
Learned that Angular now has a direct build page here: https://angular.io/guide/testing#configure-project-for-circle-ci 

References #94



