### PR TITLE
refactor(frameworks): Split out languages from frameworks

### DIFF
--- a/best-practices/server-side/framework/README.md
+++ b/best-practices/server-side/framework/README.md
@@ -9,7 +9,7 @@
   - Vue - TODO
 
 * [Python](python/README.md) - Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace.
-  - Django - TODO
+  - [Django](django/README.md) - Django is a Python-based free and open-source web framework, which follows the model-template-view architectural pattern.
   - Flask - TODO
   
 * [Ruby](ruby/README.md) - A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write. 

--- a/best-practices/server-side/framework/README.md
+++ b/best-practices/server-side/framework/README.md
@@ -1,9 +1,21 @@
-# Framework
+# Languages and Frameworks
 
 ## This is a list of relevant frameworks separated by language that are modern, but also provide an education to further develop the skills of each developer
 
-- [Node](node/README.md) - Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
-- [Python](python/README.md) - Python is a programming language that lets you work quickly and integrate systems more effectively.
-- [Ruby](ruby/README.md) - A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write. 
-- [.NET](dotnet/README.md) - .NET is a free, cross-platform, open source developer platform for building many different types of applications.
-- [PHP](php/README.md) - PHP is a popular general-purpose scripting language that is especially suited to web development.
+* Javascript - JavaScript, often abbreviated as JS, is a programming language that conforms to the ECMAScript specification. JavaScript is high-level, often just-in-time compiled, and multi-paradigm. It has curly-bracket syntax, dynamic typing, prototype-based object-orientation, and first-class functions.
+  - [Node](node/README.md) - Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+  - Angular - TODO
+  - Reactjs - TODO
+  - Vue - TODO
+
+* [Python](python/README.md) - Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace.
+  - Django - TODO
+  - Flask - TODO
+  
+* [Ruby](ruby/README.md) - A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write. 
+  - Ruby On Rails - TODO
+* C# - TODO
+  - [.NET](dotnet/README.md) - .NET is a free, cross-platform, open source developer platform for building many different types of applications.
+* [PHP](php/README.md) - PHP is a popular general-purpose scripting language that is especially suited to web development.
+  - WordPress - TODO
+  - Laravel - TODO

--- a/best-practices/server-side/framework/README.md
+++ b/best-practices/server-side/framework/README.md
@@ -6,13 +6,13 @@
   - [Node](node/README.md) - Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
 
 * [Python](python/README.md) - Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace.
-  - [Django](django/README.md) - Django is a Python-based free and open-source web framework, which follows the model-template-view architectural pattern.
+  - [Django](python/django/README.md) - Django is a Python-based free and open-source web framework, which follows the model-template-view architectural pattern.
   - Flask - Flask is a micro web framework written in Python. It is classified as a microframework because it does not require particular tools or libraries. It has no database abstraction layer, form validation, or any other components where pre-existing third-party libraries provide common functions.
   
 * [Ruby](ruby/README.md) - A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write. 
-  - Ruby On Rails - TODO
+  - Ruby On Rails - Ruby on Rails, or Rails, is a server-side web application framework written in Ruby under the MIT License. Rails is a model–view–controller framework, providing default structures for a database, a web service, and web pages.
 * C# - C# is a general-purpose, multi-paradigm programming language encompassing strong typing, lexically scoped, imperative, declarative, functional, generic, object-oriented, and component-oriented programming disciplines.
   - [.NET](dotnet/README.md) - .NET is a free, cross-platform, open source developer platform for building many different types of applications.
 * [PHP](php/README.md) - PHP is a popular general-purpose scripting language that is especially suited to web development.
-  - WordPress - TODO
-  - Laravel - TODO
+  - WordPress - WordPress is a free and open-source content management system written in PHP and paired with a MySQL or MariaDB database. Features include a plugin architecture and a template system, referred to within WordPress as Themes.
+  - [Laravel](php/laravel/README.md) - Laravel is a free, open-source PHP web framework, created by Taylor Otwell and intended for the development of web applications following the model–view–controller architectural pattern and based on Symfony.

--- a/best-practices/server-side/framework/README.md
+++ b/best-practices/server-side/framework/README.md
@@ -4,17 +4,14 @@
 
 * Javascript - JavaScript, often abbreviated as JS, is a programming language that conforms to the ECMAScript specification. JavaScript is high-level, often just-in-time compiled, and multi-paradigm. It has curly-bracket syntax, dynamic typing, prototype-based object-orientation, and first-class functions.
   - [Node](node/README.md) - Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
-  - Angular - TODO
-  - Reactjs - TODO
-  - Vue - TODO
 
 * [Python](python/README.md) - Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace.
   - [Django](django/README.md) - Django is a Python-based free and open-source web framework, which follows the model-template-view architectural pattern.
-  - Flask - TODO
+  - Flask - Flask is a micro web framework written in Python. It is classified as a microframework because it does not require particular tools or libraries. It has no database abstraction layer, form validation, or any other components where pre-existing third-party libraries provide common functions.
   
 * [Ruby](ruby/README.md) - A dynamic, open source programming language with a focus on simplicity and productivity. It has an elegant syntax that is natural to read and easy to write. 
   - Ruby On Rails - TODO
-* C# - TODO
+* C# - C# is a general-purpose, multi-paradigm programming language encompassing strong typing, lexically scoped, imperative, declarative, functional, generic, object-oriented, and component-oriented programming disciplines.
   - [.NET](dotnet/README.md) - .NET is a free, cross-platform, open source developer platform for building many different types of applications.
 * [PHP](php/README.md) - PHP is a popular general-purpose scripting language that is especially suited to web development.
   - WordPress - TODO

--- a/best-practices/server-side/framework/README.md
+++ b/best-practices/server-side/framework/README.md
@@ -4,6 +4,7 @@
 
 * Javascript - JavaScript, often abbreviated as JS, is a programming language that conforms to the ECMAScript specification. JavaScript is high-level, often just-in-time compiled, and multi-paradigm. It has curly-bracket syntax, dynamic typing, prototype-based object-orientation, and first-class functions.
   - [Node](node/README.md) - Node.js® is a JavaScript runtime built on Chrome's V8 JavaScript engine.
+  - [MEAN](/node/mean/README.md) - MEAN is a full-stack JavaScript solution that helps you build fast, robust, and maintainable production web applications using MongoDB, Express, AngularJS, and Node.js.
 
 * [Python](python/README.md) - Python is an interpreted, high-level, general-purpose programming language. Created by Guido van Rossum and first released in 1991, Python's design philosophy emphasizes code readability with its notable use of significant whitespace.
   - [Django](python/django/README.md) - Django is a Python-based free and open-source web framework, which follows the model-template-view architectural pattern.


### PR DESCRIPTION
## Changes
1. Split Programming Languages from Frameworks
2. Added more resources we use at Shift3

## Approach
* Breaking out Programming Languages from Frameworks will enable us to navigate a bit better and give general information about the specific concept before diving in to official docs.
* All descriptions have been lifted off wikipedia. 

Closes #172 



