### PR TITLE
fix(client-side-links): Deprecate client links

### DIFF
--- a/best-practices/client-side/README.md
+++ b/best-practices/client-side/README.md
@@ -1,4 +1,4 @@
 # Client Side
 
-[WCAG-testing](/best-practices/development-tools/accessibility/WCAG-testing.md) - WCAG Testing Procedure
-TODO: Add links back in
+[WCAG-testing](/best-practices/development-tools/accessibility/WCAG-testing.md) - WCAG Testing Procedures
+[Frameworks](/best-practices/client-side/framework) - Client Frameworks we use in production

--- a/best-practices/client-side/README.md
+++ b/best-practices/client-side/README.md
@@ -1,7 +1,4 @@
 # Client Side
 
-[Browser](browser/README.md)-specific tips and tricks  
-[CSS](css/README.md) standards  
-[Frameworks](framework/README.md) we use  
-[JavaScript](javascript/README.md) standards we follow  
-[Security](security/README.md) on the client
+[WCAG-testing](/best-practices/development-tools/accessibility/WCAG-testing.md) - WCAG Testing Procedure
+TODO: Add links back in


### PR DESCRIPTION
## Changes
All the old links get 404ed. None of these links are relevant anymore
1. Removed or replaced links 

## Approach
Remove or add client side links. Most links went to pages that no longer exist.

Closes #168



