### PR TITLE
Reusable phone number link component

### DIFF
--- a/best-practices/native/react-native/common-components/phone-number-test.js
+++ b/best-practices/native/react-native/common-components/phone-number-test.js
@@ -1,0 +1,27 @@
+// example jest test for phone number component
+import React from 'react';
+import { Text } from 'react-native';
+import PhoneNumber from './phone-number';
+
+import renderer from 'react-test-renderer';
+
+it('renders correctly', () => {
+  const tree = renderer.create(
+    <PhoneNumber
+      phoneNo="555-1234"
+      disallowFontScaling
+    />
+    ).toJSON();
+  expect(tree).toMatchSnapshot();
+  
+  // only one child (should be a text)
+  expect(tree.children.length).toBe(1);
+
+  const text = tree.children[0];
+  // make sure explicit and default props are as expected
+  expect(text.children[0]).toBe('555-1234');
+  expect(text.props.style[1].fontSize).toBe(12);
+  expect(text.props.allowFontScaling).toBe(false);
+    
+  
+});

--- a/best-practices/native/react-native/common-components/phone-number.js
+++ b/best-practices/native/react-native/common-components/phone-number.js
@@ -3,6 +3,11 @@ import { View, Text, StyleSheet, Linking } from 'react-native';
 import PropTypes from 'prop-types';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
 
+// Delete this comment when using this code in project
+// ---------------------------------------------------
+// This component is passed a phone number string, along with a few styling properties.
+// It returns text that when pressed, opens an action sheet giving the user an option to either call or text that number
+// This requires use of the package "react-native-action-sheet", the flavor will depend on whether or not Expo is being used.
 
 const styles = StyleSheet.create({
   phoneText: {

--- a/best-practices/native/react-native/common-components/phone-number.js
+++ b/best-practices/native/react-native/common-components/phone-number.js
@@ -50,7 +50,7 @@ class PhoneNumber extends Component {
 
 PhoneNumber.defaultProps = {
   fontSize: 12,
-  color: '#33333',
+  color: '#333333',
   lineHeight: 14,
   phoneNo: '',
   disallowFontScaling: false,

--- a/best-practices/native/react-native/common-components/phone-number.js
+++ b/best-practices/native/react-native/common-components/phone-number.js
@@ -1,0 +1,64 @@
+import React, { Component } from 'react';
+import { View, Text, StyleSheet, Linking } from 'react-native';
+import PropTypes from 'prop-types';
+import { connectActionSheet } from '@expo/react-native-action-sheet';
+
+
+const styles = StyleSheet.create({
+  phoneText: {
+      // If you have a desired font loaded, place it here as the "fontFamily" property.
+  }
+});
+
+class PhoneNumber extends Component {
+
+  _onOpenActionSheet = (phoneNo) => {
+    // Same interface as https://facebook.github.io/react-native/docs/actionsheetios.html
+    const options = [`Call:  ${phoneNo}`, `Text:  ${phoneNo}`, 'Cancel'];
+    const cancelButtonIndex = 2;
+
+    this.props.showActionSheetWithOptions(
+      {
+        options,
+        cancelButtonIndex,
+      },
+      buttonIndex => {
+        // Do something here depending on the button index selected
+        if (buttonIndex === 0) Linking.openURL(`tel:${phoneNo}`);
+        if (buttonIndex === 1) Linking.openURL(`sms:${phoneNo}`);
+      },
+    );
+  };
+
+  render() {
+    const { phoneNo, disallowFontScaling } = this.props;
+    const { fontSize, color, lineHeight } = this.props;
+
+    return (
+      <View>
+        <Text allowFontScaling={!disallowFontScaling} style={[styles.phoneText, { fontSize, color, lineHeight }]} onPress={() => this._onOpenActionSheet(phoneNo)}>{phoneNo}</Text>
+      </View>
+    );
+    
+  }
+}
+
+PhoneNumber.defaultProps = {
+  fontSize: 12,
+  color: '#33333',
+  lineHeight: 14,
+  phoneNo: '',
+  disallowFontScaling: false,
+}
+
+PhoneNumber.propTypes = {
+  fontSize: PropTypes.number,
+  color: PropTypes.string,
+  lineHeight: PropTypes.number,
+  phoneNo: PropTypes.string,
+  disallowFontScaling: PropTypes.bool,
+}
+
+const ConnectedPhone = connectActionSheet(PhoneNumber);
+
+export default ConnectedPhone;

--- a/best-practices/native/react-native/common-components/phone-number.js
+++ b/best-practices/native/react-native/common-components/phone-number.js
@@ -7,7 +7,7 @@ import { connectActionSheet } from '@expo/react-native-action-sheet';
 // ---------------------------------------------------
 // This component is passed a phone number string, along with a few styling properties.
 // It returns text that when pressed, opens an action sheet giving the user an option to either call or text that number
-// This requires use of the package "react-native-action-sheet", the flavor will depend on whether or not Expo is being used.
+// This requires use of the package "@expo/react-native-action-sheet".
 
 const styles = StyleSheet.create({
   phoneText: {


### PR DESCRIPTION
## Changes

1. Adds the reusable phone number link component

This component takes in a few props:
- A phone number
- An option to disallow scaling (So adjusting font size on the hardware level doesn't affect the component)
- Some styling options: Color, font size, and line height

It returns text that when pressed opens up an action sheet giving the user the option to either text or call the number through use of the required package, `react-native-action-sheet` (props to @carlosvargas for the find). Links for the package are below.

I recently used this component for Listing Alert, and thought it would be useful enough to go on this component list.

<img width="416" alt="Screen Shot 2020-05-18 at 1 31 13 PM" src="https://user-images.githubusercontent.com/29141727/82383655-207e5e80-99e3-11ea-893d-adf6ccfdd08c.png">


## Approach
Creating a link to either call or text a phone number is pretty easy, but giving the user the option to do either one is not. Hopefully, this helps a bit.

[Action sheet for Expo](https://github.com/expo/react-native-action-sheet)




