### PR TITLE
Centralizing code ownership to a dedicated maintainers team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @carlosvargas @ryekerjh @mwallert @coreyshuman @DropsOfSerenity
+* @coreyshuman @michaelachrisco


### PR DESCRIPTION
## Changes
Michael Chrisco will now be the primary codeowner for Standards and Practices. This is part of a larger effort to eventually have a dedicated team to maintain and apply Standards and Practices for the shop, which Chrisco will lead. This change comes with specific additional duties where Chrisco will now be responsible for merging S&P PRs and grooming the issue backlog.

## Approach
Creating a dedicated team to maintain S&P will centralize the duties and responsibilities involved with the role. The goal is to promote more activity, maintenance, and adoption of standards. A secondary goal in creating specialized teams is to distribute various efforts across the shop to address the current issue where certain team members are overloaded with extracurricular duties. Specifically this will allow Ryeker, Michael Wallert, and Justin Schiff to focus more time on developer relations, devops, and software architecture respectively. And of course Carlos who is now running an entire department himself.

Chrisco has been incredibly active in S&P maintenance and shop-wide code review tasks. Through these efforts he has proven himself as the person best suited and most prepared for this responsibility. Once I have formalized the duties and responsibilities for this team, I will be looking for team members in the shop who would like to join Chrisco as a member of the S&P maintainers team.