### PR TITLE
feat(pr-template): add helpful sections to pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,18 @@ _List Changes Introduced by this PR_
 1. Item 1
 2. Item 2
 
+## Purpose
+_Describe the problem or feature in addition to a link to the issues._
+
 ## Approach
 _How does this change address the problem?_
+
+## Pre-Testing TODOs
+_What needs to be done before testing_
+- [] Change DB values in x collection to y.
+
+## Testing Steps
+_How do the users test this change?_
 
 ## Learning
 _Describe the research stage_
@@ -13,6 +23,3 @@ _Links to blog posts, patterns, libraries or addons used to solve this problem_
 
 _If this closes an issue, name it here. If it doesn't, remove this line_
 Closes #000
-
-
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ _How does this change address the problem?_
 
 ## Pre-Testing TODOs
 _What needs to be done before testing_
-- [] Change DB values in x collection to y.
+- [] Change database values in x collection to y.
 
 ## Testing Steps
 _How do the users test this change?_


### PR DESCRIPTION
## Changes
1. Adds Purpose, Pre-testing TODOs, and Testing Steps sections to the template

## Approach
The aforementioned sections seemed to have been lost when the template was updated at some point in the past.  I find them quite helpful, and use them 99% of the time, so I figured it would be best to add them back in.

If these were removed intentionally, please let me know.

Closes #204 