### PR TITLE
feature(git-hooks): Git Hooks should be referenced

### DIFF
--- a/standards/README.md
+++ b/standards/README.md
@@ -45,6 +45,11 @@ This section describes Shift3 standards to be applied to all projects. Code revi
 - The code review process
 - Resources for code review
 
+### [Git Commands](git-commands.md)
+
+- Basics on git
+- Lesser known git commands
+
 ### Testing and QA
 
 #### [Acceptance Testing](acceptance-testing.md)

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -14,9 +14,9 @@ At Shift3, we use git for a majority of our software projects.
 
 Git Official Documentation: https://git-scm.com/docs/git-stash
 
-Git Stash is used to record the current state of the working directory and index (your code within your current branch) but want to go back to a clean working directory. In order to "stash" your code away for future use, first `git add` the files you want to stash away but *do not use git commit*. You use the `git stash push` command to create your stash. You can switch your branches and then apply the same code to the new branch with `git stash pop`. 
+Git Stash is useful when you want to go back to a clean working directory but don't want to discard your current changes. It works by locally storing the current state of the working directory and index (the code within the current branch). In order to "stash" your code away for future use, first `git add` the files you want to stash away but *do not use git commit*. You use the `git stash push` command to create your stash. You can switch your branches and then apply the same code to the new branch with `git stash pop`. 
 
-In the below example, we are pushing this readme into our `foo-999-big-feature` branch which leaves us with a clean working directory/index within our origional branch `mac-192-lesser-known-git`.
+In the below example, we are pushing this readme into our `foo-999-big-feature` branch which leaves us with a clean working directory/index within our original branch `mac-192-lesser-known-git`.
 ```shell
 $ git add standards/git-commands.md
 $ git stash push

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -31,4 +31,4 @@ Changes to be committed:
 Dropped refs/stash@{0} (1a5b247bdd51df733d9ab2e1d1aadc270eded2ce)
 ```
 
-A good visual representation can be seen in Gitkrakens documentation: https://support.gitkraken.com/working-with-commits/stashing/
+A good visual representation can be seen in Gitkrakens documentation: [Gitkraken Stashing](https://support.gitkraken.com/working-with-commits/stashing/)

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -42,3 +42,5 @@ Git Hooks are stored in the hooks subdirectory of the `.git` directory. This fol
 Hooks are unique to your local repository and will not be copied over if you create a new repository. Feel free to add, change, or remove scripts from this folder as necessary.
 
 How to use git hooks with example code from GitHub: https://githooks.com/
+
+Using Git Hooks and node: https://medium.com/@satya164/improving-nodejs-workflow-with-git-hooks-40996830619f

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -32,3 +32,58 @@ Dropped refs/stash@{0} (1a5b247bdd51df733d9ab2e1d1aadc270eded2ce)
 ```
 
 A good visual representation can be seen in Gitkrakens documentation: [Gitkraken Stashing](https://support.gitkraken.com/working-with-commits/stashing/)
+
+
+
+### Git Hooks
+
+Git Official Documentation: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+
+TODO: Description
+
+#### Client-Side Hooks
+
+TODO: Description
+
+##### pre-commit
+
+TODO: Description
+TODO: Example with node(?)
+
+##### prepare-commit-msg
+
+TODO: Description
+TODO: Example with node(?)
+
+##### commit-msg
+
+TODO: Description
+TODO: Example with node(?)
+
+##### post-commit
+
+TODO: Description
+TODO: Example with node(?)
+
+##### pre-rebase/post-rewrite/post-checkout/post-merge/pre-auto-gc
+
+TODO: Evaluate and see if useful to our workflow (post-merge might be?)
+
+#### Server-Side Hooks
+
+TODO: Description
+
+##### pre-receive
+
+TODO: Description
+TODO: Example with node(?)
+
+##### update
+
+TODO: Description
+TODO: Example with node(?)
+
+##### post-receive
+
+TODO: Description
+TODO: Example with node(?)

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -1,0 +1,31 @@
+# Git Commands
+Git is a distributed version-control system for tracking changes in source code during software development. It is designed for coordinating work among programmers, but it can be used to track changes in any set of files. Its goals include speed, data integrity, and support for distributed, non-linear workflows.
+
+At Shift3, we use git for a majority of our software projects.
+
+## Shift3 git specific resources
+1. [Commits](standards/commits.md)
+2. [Branching](standards/branching.md)
+3. [Code Versioning](standards/code-versioning.md)
+
+### Lesser known git commands
+
+#### Git Stash
+[git-stash](https://git-scm.com/docs/git-stash): `git stash` is used to record the current state of the working directory and index (your code within your current branch) but want to go back to a clean working directory. In order to "stash" your code away for future use, first `git add` the files you want to stash away but *do not use git commit*. You use the `git stash push` command to create your stash. You can switch your branches and then apply the same code to the new branch with `git stash pop`. 
+
+In the below example, we are pushing this readme into our `foo-999-big-feature` branch which leaves us with a clean working directory/index within our origional branch `mac-192-lesser-known-git`.
+```shell
+$ git add standards/git-commands.md
+$ git stash push
+Saved working directory and index state WIP on mac-192-lesser-known-git: 60a39ed Merge remote-tracking branch 'origin/master' into mac-192-lesser-known-git
+$ git checkout foo-999-big-feature
+$ git stash pop
+On branch mac-test-branch
+Changes to be committed:
+  (use "git restore --staged <file>..." to unstage)
+	new file:   standards/git-commands.md
+
+Dropped refs/stash@{0} (1a5b247bdd51df733d9ab2e1d1aadc270eded2ce)
+```
+
+A good visual representation can be seen with Gitkrakens documentation: https://support.gitkraken.com/working-with-commits/stashing/

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -37,51 +37,8 @@ A good visual representation can be seen in Gitkrakens documentation: [Gitkraken
 
 Git Official Documentation: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
 
-TODO: Description
+Git Hooks are stored in the hooks subdirectory of the `.git` directory. This folder is automatically created when you initialize a new repository in GitKraken and is located in `.git\hooks` in your project directory.
 
-#### Client-Side Hooks
+Hooks are unique to your local repository and will not be copied over if you create a new repository. Feel free to add, change, or remove scripts from this folder as necessary.
 
-TODO: Description
-
-##### pre-commit
-
-TODO: Description
-TODO: Example with node(?)
-
-##### prepare-commit-msg
-
-TODO: Description
-TODO: Example with node(?)
-
-##### commit-msg
-
-TODO: Description
-TODO: Example with node(?)
-
-##### post-commit
-
-TODO: Description
-TODO: Example with node(?)
-
-##### pre-rebase/post-rewrite/post-checkout/post-merge/pre-auto-gc
-
-TODO: Evaluate and see if useful to our workflow (post-merge might be?)
-
-#### Server-Side Hooks
-
-TODO: Description
-
-##### pre-receive
-
-TODO: Description
-TODO: Example with node(?)
-
-##### update
-
-TODO: Description
-TODO: Example with node(?)
-
-##### post-receive
-
-TODO: Description
-TODO: Example with node(?)
+How to use git hooks with example code from GitHub: https://githooks.com/

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -3,12 +3,12 @@ Git is a distributed version-control system for tracking changes in source code 
 
 At Shift3, we use git for a majority of our software projects.
 
-## Shift3 git specific resources
+## Shift3 Git specific resources
 1. [Commits](commits.md)
 2. [Branching](branching.md)
 3. [Code Versioning](code-versioning.md)
 
-### Lesser known git commands
+### Lesser known Git Commands
 
 #### Git Stash
 

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -4,14 +4,17 @@ Git is a distributed version-control system for tracking changes in source code 
 At Shift3, we use git for a majority of our software projects.
 
 ## Shift3 git specific resources
-1. [Commits](standards/commits.md)
-2. [Branching](standards/branching.md)
-3. [Code Versioning](standards/code-versioning.md)
+1. [Commits](commits.md)
+2. [Branching](branching.md)
+3. [Code Versioning](code-versioning.md)
 
 ### Lesser known git commands
 
 #### Git Stash
-[git-stash](https://git-scm.com/docs/git-stash): `git stash` is used to record the current state of the working directory and index (your code within your current branch) but want to go back to a clean working directory. In order to "stash" your code away for future use, first `git add` the files you want to stash away but *do not use git commit*. You use the `git stash push` command to create your stash. You can switch your branches and then apply the same code to the new branch with `git stash pop`. 
+
+Git Official Documentation: https://git-scm.com/docs/git-stash
+
+Git Stash is used to record the current state of the working directory and index (your code within your current branch) but want to go back to a clean working directory. In order to "stash" your code away for future use, first `git add` the files you want to stash away but *do not use git commit*. You use the `git stash push` command to create your stash. You can switch your branches and then apply the same code to the new branch with `git stash pop`. 
 
 In the below example, we are pushing this readme into our `foo-999-big-feature` branch which leaves us with a clean working directory/index within our origional branch `mac-192-lesser-known-git`.
 ```shell
@@ -28,4 +31,4 @@ Changes to be committed:
 Dropped refs/stash@{0} (1a5b247bdd51df733d9ab2e1d1aadc270eded2ce)
 ```
 
-A good visual representation can be seen with Gitkrakens documentation: https://support.gitkraken.com/working-with-commits/stashing/
+A good visual representation can be seen in Gitkrakens documentation: https://support.gitkraken.com/working-with-commits/stashing/


### PR DESCRIPTION
## Changes
1. Adds a basic description of Git Hooks.
2. Adds a link to websites that already explain git hooks better than I can.

## Purpose
To give developers an introduction to Git Hooks as a concept. 

## Approach
By adding reference websites that are actively maintained, this readme will be future proof (as long as the websites/references do not disappear). I attempted to go over each of the git hooks and how they could be used within projects at Shift3, but after going through a couple, I realized that I was assuming a LOT when it came to specific setups. It may be better to add specific scripts to boilerplate like projects instead of the S/P repo. Thoughts on this are welcome on this subject!

## Learning
There are quite a few git hooks that I have never used before and look forward to trying them out in future projects. 

Closes #192 
