### PR TITLE
feature(react-native): Working react native without expo setup

### DIFF
--- a/best-practices/development-tools/continuous-integration/react_native.yml
+++ b/best-practices/development-tools/continuous-integration/react_native.yml
@@ -1,0 +1,17 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/rn-by-example
+    docker:
+      - image: circleci/node:10-browsers
+    steps:
+      - checkout
+      - restore_cache:
+          key: rn-by-example-{{ .Branch }}-{{ checksum "package-lock.json" }}
+      - run: npm install
+      - save_cache:
+          key: rn-by-example-{{ .Branch }}-{{ checksum "package-lock.json" }}
+          paths:
+            - "node_modules"
+      - run: npm run build
+      - run: npm run test -- --no-watch --no-progress --browsers=ChromeHeadlessCI --detectOpenHandles 


### PR DESCRIPTION
## Changes
1. Add in working version of a react native CircleCI build

## Purpose
We do not currently have a react native build without expo setup and having a working one would help out on future projects. 

# Approach
Use working CircleCI build from another project and add it into our S/P repo.

# Learning

On default, jest is pretty easy to setup initially, but updating it and getting it to work with react native was a challenge. Some of those challenges on the setup side have been documented [here](https://github.com/Shift3/rn-by-example/pull/20). However, the CI portion turned out pretty simple once it was complete. 

Closes #94 
