### PR TITLE
feature(react-readme): add content to react readme

### DIFF
--- a/best-practices/client-side/framework/react/README.md
+++ b/best-practices/client-side/framework/react/README.md
@@ -1,3 +1,16 @@
-# react
+# React
 
-## all info on current dev with react, how to spin up a boilerplate
+## Intro
+
+-   [React.js](https://reactjs.org/docs/getting-started.html) often referred to as React or ReactJS is an open-source JavaScript library for building user interfaces or UI components, created by Facebook.
+
+-   [React Native](https://reactnative.dev/) is an open-source mobile application framework created by Facebook to develop applications for Android, iOS, Web and UWP by enabling developers to use React along with native platform capabilities.
+
+## Spining up a boilerplate
+
+you can refer to [Aerostar](https://github.com/Shift3/Aerostar) and [sundial-mobile-app](https://github.com/Shift3/sundial-mobile-app) repositories.
+
+## Tools that can be used for unit testing React components
+
+-   [Jest](https://jestjs.io/) is a JavaScript library for creating, running, and structuring tests.
+-   [Enzyme](https://enzymejs.github.io/enzyme/) created by Airbnbis a JavaScript Testing utility for React.

--- a/best-practices/client-side/framework/react/README.md
+++ b/best-practices/client-side/framework/react/README.md
@@ -6,11 +6,20 @@
 
 -   [React Native](https://reactnative.dev/) is an open-source mobile application framework created by Facebook to develop applications for Android, iOS, Web and UWP by enabling developers to use React along with native platform capabilities.
 
-## Spining up a boilerplate
+## Examples of react based projects
 
-you can refer to [Aerostar](https://github.com/Shift3/Aerostar) and [sundial-mobile-app](https://github.com/Shift3/sundial-mobile-app) repositories.
+To get more familiar with the structure of a React/React Native based project, below is a list of some repositiories you can look into. If you currently don't have access to any of these projects, please reach out and request access:
+
+-   [bw-project-status](https://github.com/Shift3/bw-project-status)
+-   [rn-by-example](https://github.com/Shift3/rn-by-example)
+-   [Aerostar](https://github.com/Shift3/Aerostar)
+-   [sundial-mobile-app](https://github.com/Shift3/sundial-mobile-app)
 
 ## Tools that can be used for unit testing React components
 
 -   [Jest](https://jestjs.io/) is a JavaScript library for creating, running, and structuring tests.
--   [Enzyme](https://enzymejs.github.io/enzyme/) created by Airbnbis a JavaScript Testing utility for React.
+-   [Enzyme](https://enzymejs.github.io/enzyme/) created by Airbnb is a JavaScript Testing utility for React.
+
+## Spinning up a boilerplate
+
+TODO


### PR DESCRIPTION
## Changes
1. Add intro section in the ReadMe for React  along with links to documentation
2. Add links to existing repos for boilerplates
3. Add links to Jest and Enzyme for information on testing React components

## Purpose
Currently the react ReadMe has no content and we might want to add information regarding boilerplates and testing.

## Approach
I provided links to existing repositories as an example for running a react based project along with links to documentation.

Closes #208 
