### PR TITLE
fix(awesome-whitelist): Whitelist all Shift3 resources from awesome_bot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,4 +6,4 @@ jobs:
     steps:
       - checkout
       - run: gem install awesome_bot
-      - run: awesome_bot --allow-redirect --allow-dupe -w awesome_bot --allow-redirect --allow-dupe -w https://github.com/Shift3/ifg,https://github.com/Shift3/sinclair-scanner-application,regexr,https://github.com/Shift3/rn-by-example,https://github.com/Shift3/fusd-front-desk-kiosk,https://github.com/Shift3/FUSDMonitoringAppXamarin,127.0.0.1 `find . -name "*.md"`
+      - run: awesome_bot --allow-redirect --allow-dupe -w awesome_bot --allow-redirect --allow-dupe -w https://github.com/Shift3,regexr,127.0.0.1 `find . -name "*.md"`


### PR DESCRIPTION
## Changes
1. All Shift3 resources are now whitelisted
2. Removed all specific Shift3 projects

## Purpose
To once and for all fix awesome_bot attempting to retrieve internal resources and 404ing. 

## Approach
Whitelist any Shift3 resource.

## Pre-Testing TODOs
Install gem and run the same commands as the CircleCI job. 

Closes #210
