### PR TITLE
Master to Main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 #### Git
 
 - [Gitflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow)
-  - Keep branches for master and development
+  - Keep branches for main and development
   - Branch off of development for features
   - Request reviews on your Pull Requests
   - Merge _reviewed_ code into development

--- a/best-practices/development-tools/aws/cloudfront-set-up.sh
+++ b/best-practices/development-tools/aws/cloudfront-set-up.sh
@@ -23,7 +23,7 @@ print_usage() {
 DESCRIPTION
 ---------
 
-This script automates the CloudFront set up process as documented in https://github.com/Shift3/standards-and-practices/blob/master/aws/s3-cloudfront-deployment.md.
+This script automates the CloudFront set up process as documented in https://github.com/Shift3/standards-and-practices/blob/main/aws/s3-cloudfront-deployment.md.
 
 It does the following:
     - Creates the CloudFront SSL Certificate on us-east-1 for the given domain.

--- a/best-practices/development-tools/continuous-integration/circle_ci_config.yml
+++ b/best-practices/development-tools/continuous-integration/circle_ci_config.yml
@@ -83,5 +83,5 @@ workflows:
           filters:
             branches:
               only: 
-                - master
+                - main
                 - develop

--- a/best-practices/native/react-native/expo/certificates/README.md
+++ b/best-practices/native/react-native/expo/certificates/README.md
@@ -1,6 +1,6 @@
 # App Store Credentials (Expo)
 
-*If you are not familiar with Expo, you can read about it in [this S&P article regarding React Native](https://github.com/Shift3/standards-and-practices/tree/master/best-practices/native/react-native)
+*If you are not familiar with Expo, you can read about it in [this S&P article regarding React Native](https://github.com/Shift3/standards-and-practices/tree/main/best-practices/native/react-native)
 
 Both the Google Play store and the Apple store have their own form of unique credentials when it comes to being able to create and submit builds. Expo does a good job of handling these for you, especially upon first build. Sometimes, these will expire, and then some knowledge is required to be able to fix your credentials so you can create a build and start updating again.
 

--- a/best-practices/server-side/tools/deploy-changes-since/Deploy-ChangesSince.ps1
+++ b/best-practices/server-side/tools/deploy-changes-since/Deploy-ChangesSince.ps1
@@ -3,7 +3,7 @@
 # Example usage: ./Deploy-ChangesSince.ps1 -EarliestChangeDate "2019-06-20" -DestServer "ultra-gro.shift3sandbox.com" -DestBasePath "Ultra-Gro"
 # Note that you should run this from the directory on your local machine where
 # your source code is located. Also, make sure that you have the latest source
-# (preferably from the master branch) checked out before you run this script!
+# (preferably from the main branch) checked out before you run this script!
 # 
 # Finally, make sure to give the correct path to Deploy-ChangesSince.ps1,
 # either absolute or relative. Even if you're in the same directory as this

--- a/standards/branching.md
+++ b/standards/branching.md
@@ -1,14 +1,14 @@
 ### Branch Structure
 
 ```
-Master
+Main
 L- Staging
 L- Development
    L- *Feature Branch*
    L- *Bug fix branch*
 ```
 
-**Master** branch is for finalized, tested, and production-ready code.
+**Main** branch is for finalized, tested, and production-ready code.
 
 **Staging** branch is for finalized, tested, and demo-ready code.
 
@@ -27,7 +27,7 @@ For example, if I'm (Corey) working on an bug fix task, I'll create a branch suc
 
 When work is completed and tested, make a Pull Request to the development branch. This PR requires review from another developer before it is merged.
 
-When code is ready to be locked in for demo, a Pull Request from `development` to `master` will be created and reviewed.
+When code is ready to be locked in for demo, a Pull Request from `development` to `main` will be created and reviewed.
 
 ### Doing Development
 - Always have an issue created for any work you are doing. It should contain:

--- a/standards/code-versioning.md
+++ b/standards/code-versioning.md
@@ -57,7 +57,7 @@ Let's go through our use cases:
 ### I need to increment my project's patch version
 
 1. Be sure your hotfix or bugfix changes have been reviewed and approved by your project's lead developer
-2. Once the fix is approved and your Pull Request is merged, checkout to your base branch (develop or master, whatever you use as your source of truth) and pull your changes
+2. Once the fix is approved and your Pull Request is merged, checkout to your base branch (develop or main, whatever you use as your source of truth) and pull your changes
 3. Create your tag using `git tag v0.1.1`, remembering to increment from the last patch version, but keeping the major and minor versions the same.
 4. Push your tag to GitHub.com using `git push origin <YOUR-TAG-NAME>`
    _Note: < YOUR-TAG-NAME > would be replaced by `v0.1.1` in our above example and *must* match_
@@ -65,7 +65,7 @@ Let's go through our use cases:
 ### I need to increment my project's minor version
 
 1. Be sure your feature branch changes have been reviewed and approved by your project's lead developer
-2. Checkout to your base branch (develop or master, whatever you use as your source of truth) and pull your changes
+2. Checkout to your base branch (develop or main, whatever you use as your source of truth) and pull your changes
 3. Create your tag using `git tag v0.2.0`, remembering to increment from the last minor version, keeping the major version the same and resetting the patch version to 0.
 4. Push your tag to GitHub.com using `git push origin <YOUR-TAG-NAME>`
    _Note: < YOUR-TAG-NAME > would be replaced by `v0.2.0` in our above example and *must* match_
@@ -74,7 +74,7 @@ Let's go through our use cases:
 
 1. Be sure your reverse-incompatable, breaking changes have been reviewed and approved by your project's lead developer.
 2. Make a plan for your rollout to users with your client and make sure your deployment follows that plan.
-3. Checkout to your base branch (develop or master, whatever you use as your source of truth) and pull your changes
+3. Checkout to your base branch (develop or main, whatever you use as your source of truth) and pull your changes
 4. Create your tag using `git tag v1.0.0`, remembering to increment from the last major version and resetting your minor and patch versions to 0.
 5. Push your tag to GitHub.com using `git push origin <YOUR-TAG-NAME>`
    _Note: < YOUR-TAG-NAME > would be replaced by `v1.0.0` in our above example and *must* match_

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -20,7 +20,7 @@ In the below example, we are pushing this readme into our `foo-999-big-feature` 
 ```shell
 $ git add standards/git-commands.md
 $ git stash push
-Saved working directory and index state WIP on mac-192-lesser-known-git: 60a39ed Merge remote-tracking branch 'origin/master' into mac-192-lesser-known-git
+Saved working directory and index state WIP on mac-192-lesser-known-git: 60a39ed Merge remote-tracking branch 'origin/main' into mac-192-lesser-known-git
 $ git checkout foo-999-big-feature
 $ git stash pop
 On branch mac-test-branch

--- a/standards/issue-template.md
+++ b/standards/issue-template.md
@@ -10,7 +10,7 @@ Follow the [step by step guide](https://help.github.com/en/github/building-a-str
 1. Go to your repository's `Settings` tab.
 2. Under the `Options` section, scroll down to **Features**.
 3. Make sure **Issues** option is selected (check the box) and click the `Set up templates` button.
-4. Select which type of template you want to set up. Github has pre-configured templates that you can choose to use. You can edit the default templates if you need to, or you can add a custom template manually. We have two issue templates in this repository for [Feature Request](https://github.com/Shift3/standards-and-practices/blob/master/.github/ISSUE_TEMPLATE/feature_request.md) and [Bug Reports](https://github.com/Shift3/standards-and-practices/blob/master/.github/ISSUE_TEMPLATE/bug_report.md) that are a good starting point.
+4. Select which type of template you want to set up. Github has pre-configured templates that you can choose to use. You can edit the default templates if you need to, or you can add a custom template manually. We have two issue templates in this repository for [Feature Request](https://github.com/Shift3/standards-and-practices/blob/main/.github/ISSUE_TEMPLATE/feature_request.md) and [Bug Reports](https://github.com/Shift3/standards-and-practices/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) that are a good starting point.
 5. Once you are happy with the template, click on the green `Propose changes` button at the top right of the page.
 6. Fill out the commit information that pops up. Choose the option to create a new branch and start a pull request rather than committing directly to your default branch.
 7. Have your team review and approve your pull request. Once it is closed, you will have issue templates.

--- a/standards/readme-guidelines.md
+++ b/standards/readme-guidelines.md
@@ -58,11 +58,11 @@ Supports printing commands for the TSP100 Thermal Receipt Printer.
 - Update the release notes file
 - Check in and merge project to Github
   - Check in the project and create a PR into `Development`
-  - After PR is merged, create a PR into `Master`
+  - After PR is merged, create a PR into `Main`
 - Create a Release on Github
   - After PR is merged, go to `Releases` on Github and click on `Create New Release`
   - For the tag version, enter the full version Number. For example: `v1.3.6543.18931`
-  - The target for the release should be the `Master` branch (default option)
+  - The target for the release should be the `Main` branch (default option)
   - For the release title, enter: `Magtek Card Reader Middleware Release vX.X` where `x.x` is the first two digits of the release number
   - Copy the release notes into the release description textbox
   - Attach the installer zip file in the upload area


### PR DESCRIPTION
## Changes
1. Blanket changes references from `master` branch to `main` branch.

## Purpose
To change all branch references from master to main on October 1st, the same day GitHub will be changing all new and some existing default branches.

## Approach
By changing this repo first, we get a head start on the new branch changes that will come into effect shortly.

This will be a Work in Progress until Oct 1st. On October 1st, the WIP will be removed. 

Closes #206 
