### PR TITLE
Workshops - Description and Past Workshop Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Using Chocolatey has several advantages:
 ###### Meetings are now split into two types:
 
 - *[Presentations](presentations/README.md)*: Twice a month the developers meet on every other Wednesday from 4:00pm - 5:00pm PST to discuss a new Standard or Practice for the company, shared experiences with tools the developer(s) used, or just a topic they find interesting related to development. You are highly encouraged to participate actively by leading a meeting on a topic of your choice. Ask Ryeker Herndon to add you to the GCal event so that you get reminders and emails.
-- *Workshops*: Once a month we will do a deep dive into a topic of interest for our workflow and/or processes. These will typically take longer than 1 hour, and will be a classroom/workshop setting. One developer will lead the workshop and the goal will be to produce developers who are proficient at a skill or process that will help us in our work.
+- *[Workshops](workshops/README.md)*: Once a month we will do a deep dive into a topic of interest for our workflow and/or processes. These will typically take longer than 1 hour, and will be a classroom/workshop setting. One developer will lead the workshop and the goal will be to produce developers who are proficient at a skill or process that will help us in our work.
 
 ##### Frontend Masters:
 

--- a/workshops/README.md
+++ b/workshops/README.md
@@ -1,0 +1,9 @@
+# S&P Workshops
+
+## Slide Decks and Videos
+
+These workshops provide continuous training and education for the development team. You can expect a hands-on learning experience so bring your computer, your brain, and lots of coffee. We want every developer to be involved, so please coordinate with your PM to adjust schedules as necessary. Before the workshop we will share any resources or setup instructions required to participate. The spreadsheet below is a compilation of repositories and videos (if available) of Standards and Practices workshops given. 
+
+[Shift3 Technologies Workshops](https://docs.google.com/spreadsheets/d/1PQmc5lWzHUeYE3eoDoX3lwgAfavfr1XG4bRb_1y_1gU/edit?usp=sharing)
+
+**If you don't already have access to this (not a member of the Bitwise group on Google, for example), request access!**


### PR DESCRIPTION
## Changes
1. Adds workshop description
2. Adds workshop google doc link. Let me know if we have a prefered place for this. Current rights are that anyone from bitwise can edit/view. 

## Purpose
Developers (or any user) should be able get information on workshops as well as past videos/repo links.

## Approach
Adding a basic description + google doc with specifics. Not sure if we wanted to stay private, so I went with the same standard as the presentation page.

Closes #212 
