### PR TITLE
Development to Staging Branch for Demos

### DIFF
--- a/standards/branching.md
+++ b/standards/branching.md
@@ -27,7 +27,9 @@ For example, if I'm (Corey) working on an bug fix task, I'll create a branch suc
 
 When work is completed and tested, make a Pull Request to the development branch. This PR requires review from another developer before it is merged.
 
-When code is ready to be locked in for demo, a Pull Request from `development` to `main` will be created and reviewed.
+When code is ready to be locked in for demo, a Pull Request from `development` to `staging` will be created and reviewed.
+
+When code is ready to be deployed, a Pull Request from `development` to `main` will be created and reviewed.
 
 ### Doing Development
 - Always have an issue created for any work you are doing. It should contain:


### PR DESCRIPTION
## Changes
1. Added reference to Staging branch for demos.
2. Added reference to Main branch for production.

## Purpose
Demos should be run based on the staging branch and not the development branch. 

## Approach
Make explicit references to Development, Staging, and Main branches.

Closes #218
