### PR TITLE
React Native - Example CircleCI docs with orb 

### DIFF
--- a/best-practices/native/react-native/README.md
+++ b/best-practices/native/react-native/README.md
@@ -13,7 +13,8 @@ There are typically 2 options for React Native development:
     * You should read the [caveats](https://facebook.github.io/react-native/docs/getting-started#caveats) on using Expo, but for Shift3, the main drawbacks are:
         1. If your project will need background support (the app should keep running when not in focus) DO NOT use Expo 
 2. [Native Code](startup/native-code.md)
-    * This is a more difficult project to start up, but you have more flexibility once it's started that with Expo. 
+    * This is a more difficult project to start up, but you have more flexibility once it's started that with Expo.
+    * CircleCI contains [a community orb](https://circleci.com/developer/orbs/orb/react-native-community/react-native) with a setup already in place and several examples. 
 
 ## Then what?
 - After you have started up your project, take a look at our [common components](common-components/README.md) for some base starting points.  

--- a/best-practices/native/react-native/README.md
+++ b/best-practices/native/react-native/README.md
@@ -13,7 +13,7 @@ There are typically 2 options for React Native development:
     * You should read the [caveats](https://facebook.github.io/react-native/docs/getting-started#caveats) on using Expo, but for Shift3, the main drawbacks are:
         1. If your project will need background support (the app should keep running when not in focus) DO NOT use Expo 
 2. [Native Code](startup/native-code.md)
-    * This is a more difficult project to start up, but you have more flexibility once it's started that with Expo.
+    * This is a more difficult project to start up, but you have more flexibility once it's started than with Expo.
     * CircleCI contains [a community orb](https://circleci.com/developer/orbs/orb/react-native-community/react-native) with a setup already in place and several examples. 
 
 ## Then what?


### PR DESCRIPTION
## Changes
1. Add link to CircleCI setup and example app
2. Specific to react-native

## Purpose
React Native only has some sparse documentation when it comes to the CI setup. We still need to document a majority of this work so others can move forward quicker when it comes to react-native projects. 

## Approach
This change shows a non-trivial example of a non-trivial CircleCI setup as well as examples of an android/ios setup. We took some of this to create the current Sundial android setup. 

## Learning
One doesn't necessarily need the linked orb to move forward with the CI job, but you can still re-use a majority of the commands and setups contained within: https://circleci.com/developer/orbs/orb/react-native-community/react-native 

References #226 
