### PR TITLE
doc(azure-devo-ops): Add a documentation for deployment using azure DevOps

### DIFF
--- a/best-practices/development-tools/azure/devops/README.md
+++ b/best-practices/development-tools/azure/devops/README.md
@@ -1,0 +1,12 @@
+# Deploying a .NET CORE APP using Azure DevOps
+
+## Deploying into AWS Elastic Beanstalk
+- [Elastic Beanstalk Deployment](deployment/aws-elasticbeanstalk/aws-elastic-beanstalk-deployment.md)
+
+## Deploying into Azure APP Functions
+- [Azure APP Functions Deployment](deployment/azure-app-functions/azure-app-functions-deployment.md)
+
+<br /><br />
+# Testing a .NET CORE APP using Azure DevOps
+
+- [Azure APP Functions continues integration](continuous-integration/azure-app-functions-continuous-integration.md)

--- a/best-practices/development-tools/azure/devops/README.md
+++ b/best-practices/development-tools/azure/devops/README.md
@@ -11,4 +11,4 @@ Azure function apps run your code in a serverless environment without having to 
 
 # Testing a .NET CORE APP using Azure DevOps
 
-- [Azure APP Functions continues integration](continuous-integration/azure-app-functions-continuous-integration.md)
+- [Azure APP Functions continuous integration](continuous-integration/azure-app-functions-continuous-integration.md)

--- a/best-practices/development-tools/azure/devops/README.md
+++ b/best-practices/development-tools/azure/devops/README.md
@@ -1,12 +1,14 @@
 # Deploying a .NET CORE APP using Azure DevOps
 
 ## Deploying into AWS Elastic Beanstalk
+AWS Elastic Beanstalk is an easy-to-use service for deploying and scaling web applications and services developed with Java, .NET, PHP, Node.js, Python, Ruby, Go, and Docker on familiar servers such as Apache, Nginx, Passenger, and IIS.
 - [Elastic Beanstalk Deployment](deployment/aws-elasticbeanstalk/aws-elastic-beanstalk-deployment.md)
 
-## Deploying into Azure APP Functions
+## Deploying into Azure Function APPs
+Azure function apps run your code in a serverless environment without having to first create a virtual machine (VM) or publish a web application, In addition to group functions as a logical unit for easier management, deployment, scaling, and sharing of resources.
 - [Azure APP Functions Deployment](deployment/azure-app-functions/azure-app-functions-deployment.md)
 
-<br /><br />
+
 # Testing a .NET CORE APP using Azure DevOps
 
 - [Azure APP Functions continues integration](continuous-integration/azure-app-functions-continuous-integration.md)

--- a/best-practices/development-tools/azure/devops/continuous-integration/azure-app-functions-continuous-integration.md
+++ b/best-practices/development-tools/azure/devops/continuous-integration/azure-app-functions-continuous-integration.md
@@ -1,0 +1,5 @@
+# Continuous Integration using Azure DevOps
+
+## .NET Core Unit Test
+1. Create a new Pipeline then choose `Github yaml` . Choose the target repository from GitHub. Choose `ASP.NET Core` template, then attach it to `azure-pipelines-azure-app-functions-ci.yml`.
+2. Select above created pipeline then Click on `Edit` then Click on `Variables` to define a list of all variables have been used with running test command.

--- a/best-practices/development-tools/azure/devops/continuous-integration/azure-app-functions-continuous-integration.md
+++ b/best-practices/development-tools/azure/devops/continuous-integration/azure-app-functions-continuous-integration.md
@@ -8,4 +8,4 @@
 5. Get the pipeline from `azure-pipelines-azure-app-functions-ci.yml`.
 6. Click on `Variables` to define a list of all variables have been used with running test command.
 7. Click on `Save and run`.
-8. Choose above created pipeline. click on `Edit` then `Triggers` from right-hand side. make sure to check `Enable continuous integration` under `Pull request validation`. (To trigger above pipeline process after each commit into the pull request).
+8. Choose above created pipeline. Click on `Edit` then `Triggers` from right-hand side. Make sure to check `Enable continuous integration` under `Pull request validation` (To trigger above pipeline process after each commit into the pull request).

--- a/best-practices/development-tools/azure/devops/continuous-integration/azure-app-functions-continuous-integration.md
+++ b/best-practices/development-tools/azure/devops/continuous-integration/azure-app-functions-continuous-integration.md
@@ -1,5 +1,11 @@
 # Continuous Integration using Azure DevOps
 
 ## .NET Core Unit Test
-1. Create a new Pipeline then choose `Github yaml` . Choose the target repository from GitHub. Choose `ASP.NET Core` template, then attach it to `azure-pipelines-azure-app-functions-ci.yml`.
-2. Select above created pipeline then Click on `Edit` then Click on `Variables` to define a list of all variables have been used with running test command.
+1. Go to the Pipelines page in Azure DevOps and choose New Pipeline.
+2. Choose `Github Yaml`.
+3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth. If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default github branch then continue.
+4. On the Choose a Template page, select `ASP.NET Core` template and choose `Apply`.
+5. Get the pipeline from `azure-pipelines-azure-app-functions-ci.yml`.
+6. Click on `Variables` to define a list of all variables have been used with running test command.
+7. Click on `Save and run`.
+8. Choose above created pipeline. click on `Edit` then `Triggers` from right-hand side. make sure to check `Enable continuous integration` under `Pull request validation`. (To trigger above pipeline process after each commit into the pull request).

--- a/best-practices/development-tools/azure/devops/continuous-integration/azure-pipelines-azure-app-functions-ci.yml
+++ b/best-practices/development-tools/azure/devops/continuous-integration/azure-pipelines-azure-app-functions-ci.yml
@@ -1,0 +1,89 @@
+# .NET Core Function App to Windows on Azure
+# Build a .NET Core function app and deploy it to Azure as a Windows function App.
+# Add steps that analyze code, save build artifacts, deploy, and more:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/languages/dotnet-core
+
+trigger:
+- main
+
+variables:
+  # Agent VM image name
+  vmImageName: 'vs2017-win2016'
+
+  # Working Directory
+  workingDirectory: '**'
+
+  TestFilesPath: '$(System.DefaultWorkingDirectory)\<testing-folder>\bin\$(buildConfiguration)\netcoreapp3.1'
+
+stages:
+- stage: Build
+  displayName: Build stage
+
+  jobs:
+  - job: Build
+    displayName: Build
+    pool:
+      vmImage: $(vmImageName)
+
+    steps:
+    - task: DotNetCoreCLI@2
+      displayName: Build
+      inputs:
+        command: 'build'
+        projects: |
+          $(workingDirectory)/*.csproj
+        arguments: --output $(System.DefaultWorkingDirectory)/publish_output --configuration Release
+
+    - task: ArchiveFiles@2
+      displayName: 'Archive files'
+      inputs:
+        rootFolderOrFile: '$(System.DefaultWorkingDirectory)/publish_output'
+        includeRootFolder: false
+        archiveType: zip
+        archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+        replaceExistingArchive: true
+    
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: drop'
+      inputs:
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+        ArtifactName: 'drop'
+        publishLocation: 'Container'
+
+- stage: Test
+  displayName: Testing app stage
+  dependsOn: build
+  condition: succeeded()
+
+  jobs:
+  - job: Test
+    displayName: Testing app job
+    pool:
+      vmImage: $(vmImageName)
+
+    steps:
+    - task: PowerShell@2
+      displayName: Create test files
+      inputs:
+        targetType: 'inline'
+        script: '<Any-Needed-Scripts>' #Like creating environment variables or files.
+    - task: PowerShell@2
+      displayName: Initial environments variables
+      inputs:
+        targetType: 'inline'
+        script: |
+            [Environment]::SetEnvironmentVariable("Actual_Variable_Name", "$(Variable_Name_Library_To_Replace)", "Machine")
+    - task: DotNetCoreCLI@2
+      displayName: Testing script
+      inputs:
+        command: 'test'
+        arguments: '--configuration $(buildConfiguration) /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(Build.SourcesDirectory)/TestResults/Coverage/'
+        publishTestResults: true
+        projects: '**/<testing-folder>/*.csproj' # update with your test project directory
+
+    - task: PublishCodeCoverageResults@1
+      displayName: 'Publish code coverage report'
+      inputs:
+        codeCoverageTool: 'Cobertura'
+        summaryFileLocation: '$(Build.SourcesDirectory)/**/coverage.cobertura.xml'
+

--- a/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/aws-elastic-beanstalk-deployment.md
+++ b/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/aws-elastic-beanstalk-deployment.md
@@ -1,0 +1,77 @@
+# Deploying into AWS Elastic Beanstalk
+
+## Pre-Deployment
+### Install AzureDevOps Extensions
+There are two extensions should be installed before in AzureDevOps [AWS Toolkit for Azure DevOps](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-vsts-tools&targetId=af056fb1-e0c2-4678-9ac3-dee687452af2&utm_source=vstsproduct&utm_medium=ExtHubManageList) and [ReplaceTokens](https://marketplace.visualstudio.com/items?itemName=citrus-andriessen.cag-replace-tokens&targetId=af056fb1-e0c2-4678-9ac3-dee687452af2&utm_source=vstsproduct&utm_medium=ExtHubManageList).
+
+### Configure AzureDevOps Service Connection
+Navigate to the project in AzureDevOps then choose Project Settings. In the Project Settings page navigate to the Service Connections page. Choose Create service connection, select AWS, and choose Next. Input an Access Key ID and Secret Access Key. (You’ll need an IAM user with permissions for Amazon ECR and Amazon ECS in order to deploy via the Azure DevOps pipeline.) Choose Save. (Get the Access Key ID and Secret Access Key credentials from Vault)
+
+## Docker with ECR deployment
+### Option 1
+1. Go to the pipeline page in Azure DevOps and choose New Pipeline.
+2. Choose `Use the classic editor`.
+3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth . If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default branch then continue.
+4. On the Choose a Template page, select Docker Container and choose Apply.
+5. Remove the `Push an image` task.
+6. Add an `Amazon ECR Push` task to the end of the tasks list by choosing the + symbol next to Agent job 1. You can search for “AWS” in the Add tasks page to filter for all AWS tasks.
+7. Add a `Replace Tokens` task to the top of the tasks list by choosing the + symbol next to Agent job 1. You can search for “Replace” in the Add tasks page to filter.
+8. Choose `Replace Tokens` and make sure to have the following settings:
+  - Source Path: `.`.
+  - Target File Pattern: `appsettings.json`.
+  - Token Regex: In the project this syntax `#{(\w+)}#` has been used.
+  - Token to Replace: ` Actual_Variable_Name:$(Variable_Name_Library_To_Replace)
+                        ...
+                        `
+Note: The Azure DevOps instance manages environment variables for each environment. To add a new environment variables, add them to the `replaceTokenList` property in the pipeline. Then update `appsettings.json` to use that value with the `#{example}#` syntax. Finally the variable and its value need to be added to the [Azure DevOps pipeline Library].
+9. Choose `Docker` task and configure its information. like the image name and display name.
+10. Choose `Push Image To Amazon ECR` and make sure to have the following settings:
+   -  Aws Credentials : Select the service connection [Configure AzureDevOps Service Connection](#Azure_DevOps_AWS_Connection).
+   -  Aws Region: Select the proper region that has the ECR repository in AWS.
+   -  Source Image Name: Should be the same `Image Name` that has been entered in previous task.
+   -  Target Repository Name: Get the repository name from AWS ECR.
+
+11.  Choose `Triggers` tab from top and make sure to check `Enable continuous integration` under Continuous integration. (To trigger deployment process after each commit to the default branch).
+12.  Choose `Variables` tab from top then choose `Variable groups` then click `Link variable group`. (To link it with environments that have been created in pipeline Library above).
+13.  Choose Save and queue to try it.
+14.  Upload `Dockerrun.aws.json` (That has a link to docker image)file to Elastic Beanstalk. [Upload File to Elastic Beanstalk](#upload_file_to_elastic_beanstalk).
+
+### Option 2
+Create a new Pipeline then choose `Github yaml` then choose the repository then choose `docker` template then attach to `azure-pipelines-aws-eb-docker-cd.yml`.
+
+## .NET Core with deploy to Elastic Beanstalk
+### Option 1
+1. Go to the pipeline page within Azure DevOps and choose New Pipeline.
+2. Choose Use the classic editor.
+3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth . If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default branch then continue.
+4. On the Choose a Template page, select ASP.NET Core and choose Apply.
+5. Add an `Deploy to Elastic Beanstalk` task to the end of the tasks list by choosing the + symbol next to Agent job 1. You can search for “AWS” in the Add tasks page to filter for all AWS tasks.
+6. Add a `Replace Tokens` task to the top of the tasks list by choosing the + symbol next to Agent job 1. You can search for “Replace” in the Add tasks page to filter.
+7. Choose `Replace Tokens` and make sure to have the following settings:
+  - Source Path: `.`.
+  - Target File Pattern: `appsettings.json`.
+  - Token Regex: In the project this syntax `#{(\w+)}#` has been used.
+  - Token to Replace: ` Actual_Variable_Name:$(Variable_Name_Library_To_Replace)
+                        ...
+                        `
+Note: The Azure DevOps instance manages environment variables for each environment. To add a new environment variables, add them to the `replaceTokenList` property in the pipeline. Then update `appsettings.json` to use that value with the `#{example}#` syntax. Finally the variable and its value need to be added to the [Azure DevOps pipeline Library].
+
+8. Choose `Publish` and make sure to have the following settings:
+  - Arguments: `--configuration $(BuildConfiguration) --output $(build.artifactstagingdirectory)`
+  - Zip published projects: `Unchecked`.
+  - Add project's folder name to publish path: `Unchecked`.
+
+9.  Choose `Deploy to Elastic Beanstalk` and make sure to have the following settings:
+  - Aws Credentials : Select the service connection [Configure AzureDevOps Service Connection](#Azure_DevOps_AWS_Connection).
+  - Aws Region: Select the proper region that has the ECR repository in AWS.
+  - Application Name: Elastic Beanstalk project name in AWS.
+  - Environment Name: Under above project get the proper environment name in AWS.
+  - Deploy Bundle Type: `ASP.NET CORE (Source: dotnet publish)`.
+  - Published Applicaion Path: `$(build.artifactstagingdirectory)`.
+
+10. Choose `Triggers` tab from top and make sure to check `Enable continuous integration` under Continuous integration. (To trigger deployment process after each commit to Dev branch).
+11. Choose `Variables` tab from top then choose `Variable groups` then click `Link variable group`. (To link it with environments that have been created in pipeline Library above).
+12. Choose Save and queue to try it.
+
+### Option 2
+Create a new Pipeline then choose `Github yaml` then choose the repository then choose `asp.net core` template then attach to `azure-pipelines-aws-eb-cd.yml`.

--- a/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/aws-elastic-beanstalk-deployment.md
+++ b/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/aws-elastic-beanstalk-deployment.md
@@ -2,7 +2,9 @@
 
 ## Pre-Deployment
 ### Install AzureDevOps Extensions
-There are two extensions should be installed before in AzureDevOps [AWS Toolkit for Azure DevOps](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-vsts-tools&targetId=af056fb1-e0c2-4678-9ac3-dee687452af2&utm_source=vstsproduct&utm_medium=ExtHubManageList) and [ReplaceTokens](https://marketplace.visualstudio.com/items?itemName=citrus-andriessen.cag-replace-tokens&targetId=af056fb1-e0c2-4678-9ac3-dee687452af2&utm_source=vstsproduct&utm_medium=ExtHubManageList).
+Please install the following two extensions:
+- [AWS Toolkit for Azure DevOps](https://marketplace.visualstudio.com/items?itemName=AmazonWebServices.aws-vsts-tools&targetId=af056fb1-e0c2-4678-9ac3-dee687452af2&utm_source=vstsproduct&utm_medium=ExtHubManageList).
+- [ReplaceTokens](https://marketplace.visualstudio.com/items?itemName=citrus-andriessen.cag-replace-tokens&targetId=af056fb1-e0c2-4678-9ac3-dee687452af2&utm_source=vstsproduct&utm_medium=ExtHubManageList).
 
 ### Configure AzureDevOps Service Connection
 Navigate to the project in AzureDevOps then choose Project Settings. In the Project Settings page navigate to the Service Connections page. Choose Create service connection, select AWS, and choose Next. Input an Access Key ID and Secret Access Key. (You’ll need an IAM user with permissions for Amazon ECR and Amazon ECS in order to deploy via the Azure DevOps pipeline.) Choose Save. (Get the Access Key ID and Secret Access Key credentials from Vault)

--- a/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/aws-elastic-beanstalk-deployment.md
+++ b/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/aws-elastic-beanstalk-deployment.md
@@ -11,7 +11,7 @@ Navigate to the project in AzureDevOps then choose Project Settings. In the Proj
 ### Option 1
 1. Go to the pipeline page in Azure DevOps and choose New Pipeline.
 2. Choose `Use the classic editor`.
-3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth . If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default branch then continue.
+3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth . If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default github branch then continue.
 4. On the Choose a Template page, select Docker Container and choose Apply.
 5. Remove the `Push an image` task.
 6. Add an `Amazon ECR Push` task to the end of the tasks list by choosing the + symbol next to Agent job 1. You can search for “AWS” in the Add tasks page to filter for all AWS tasks.
@@ -31,7 +31,7 @@ Note: The Azure DevOps instance manages environment variables for each environme
    -  Source Image Name: Should be the same `Image Name` that has been entered in previous task.
    -  Target Repository Name: Get the repository name from AWS ECR.
 
-11.  Choose `Triggers` tab from top and make sure to check `Enable continuous integration` under Continuous integration. (To trigger deployment process after each commit to the default branch).
+11.  Choose `Triggers` tab from top and make sure to check `Enable continuous integration` under Continuous integration. (To trigger deployment process after each commit to the default github branch).
 12.  Choose `Variables` tab from top then choose `Variable groups` then click `Link variable group`. (To link it with environments that have been created in pipeline Library above).
 13.  Choose Save and queue to try it.
 14.  Upload `Dockerrun.aws.json` (That has a link to docker image)file to Elastic Beanstalk. [Upload File to Elastic Beanstalk](#upload_file_to_elastic_beanstalk).
@@ -43,7 +43,7 @@ Create a new Pipeline then choose `Github yaml` then choose the repository then 
 ### Option 1
 1. Go to the pipeline page within Azure DevOps and choose New Pipeline.
 2. Choose Use the classic editor.
-3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth . If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default branch then continue.
+3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth . If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default github branch then continue.
 4. On the Choose a Template page, select ASP.NET Core and choose Apply.
 5. Add an `Deploy to Elastic Beanstalk` task to the end of the tasks list by choosing the + symbol next to Agent job 1. You can search for “AWS” in the Add tasks page to filter for all AWS tasks.
 6. Add a `Replace Tokens` task to the top of the tasks list by choosing the + symbol next to Agent job 1. You can search for “Replace” in the Add tasks page to filter.
@@ -69,7 +69,7 @@ Note: The Azure DevOps instance manages environment variables for each environme
   - Deploy Bundle Type: `ASP.NET CORE (Source: dotnet publish)`.
   - Published Applicaion Path: `$(build.artifactstagingdirectory)`.
 
-10. Choose `Triggers` tab from top and make sure to check `Enable continuous integration` under Continuous integration. (To trigger deployment process after each commit to Dev branch).
+10. Choose `Triggers` tab from top and make sure to check `Enable continuous integration` under Continuous integration. (To trigger deployment process after each commit to the default github branch).
 11. Choose `Variables` tab from top then choose `Variable groups` then click `Link variable group`. (To link it with environments that have been created in pipeline Library above).
 12. Choose Save and queue to try it.
 

--- a/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/azure-pipelines-aws-eb-cd.yml
+++ b/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/azure-pipelines-aws-eb-cd.yml
@@ -1,0 +1,75 @@
+
+trigger:
+  - main
+
+variables:
+  vmImageName: windows-latest
+
+stages:
+  - stage: Production
+    displayName: Deploy to the production after building
+    variables:
+      - group: env_variables
+
+    jobs:
+      - job: Build_Deployment
+        displayName: 'Build then deploy to the production environment'
+        pool:
+          vmImage: $(vmImageName)
+
+        steps:
+          - task: citrus-andriessen.cag-replace-tokens.custom-build-release-task.ReplaceTokens@1
+            displayName: 'Replace Tokens'
+            inputs:
+              sourcePath: .
+              targetFilePattern: appsettings.json
+              tokenRegex: '#{(\w+)}#'
+              replaceTokenList: |
+                                Actual_Variable_Name:$(Variable_Name_Library_To_Replace)
+                                ...
+              throwExceptionifNotMapped: true
+
+          - task: DotNetCoreCLI@2
+            displayName: Restore
+            inputs:
+              command: restore
+              projects: '$(Parameters.RestoreBuildProjects)'
+
+          - task: DotNetCoreCLI@2
+            displayName: Build
+            inputs:
+              projects: '$(Parameters.RestoreBuildProjects)'
+              arguments: '--configuration $(BuildConfiguration)'
+
+          - task: DotNetCoreCLI@2
+            displayName: Test
+            inputs:
+              command: test
+              projects: '$(Parameters.TestProjects)'
+              arguments: '--configuration $(BuildConfiguration)'
+
+          - task: DotNetCoreCLI@2
+            displayName: Publish
+            inputs:
+              command: publish
+              publishWebProjects: True
+              arguments: '--configuration $(BuildConfiguration) --output $(build.artifactstagingdirectory)'
+              zipAfterPublish: false
+              modifyOutputPath: false
+
+          - task: PublishBuildArtifacts@1
+            displayName: 'Publish Artifact'
+            inputs:
+              PathtoPublish: '$(build.artifactstagingdirectory)'
+            condition: succeededOrFailed()
+
+          - task: AmazonWebServices.aws-vsts-tools.BeanstalkDeployApplication.BeanstalkDeployApplication@1
+            displayName: 'Deploy to Elastic Beanstalk'
+            inputs:
+              awsCredentials: 'Azure-AWS'
+              regionName: <aws-region>
+              applicationName: <applocation-name>
+              environmentName: <environment-name>
+              applicationType: aspnetCoreWindows
+              dotnetPublishPath: '$(build.artifactstagingdirectory)'
+

--- a/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/azure-pipelines-aws-eb-docker-cd.yml
+++ b/best-practices/development-tools/azure/devops/deployment/aws-elasticbeanstalk/azure-pipelines-aws-eb-docker-cd.yml
@@ -1,0 +1,44 @@
+
+trigger:
+  - main
+
+variables:
+  vmImageName: windows-latest
+
+stages:
+  - stage: Production
+    displayName: Deploy to AWS ECR using Docker
+    variables:
+      - group: env_variables
+
+    jobs:
+      - job: Docker_Deployment
+        displayName: 'Build Docker Image then deploy to AWS ECR Container'
+        pool:
+          vmImage: $(vmImageName)
+        steps:
+          - task: citrus-andriessen.cag-replace-tokens.custom-build-release-task.ReplaceTokens@1
+            displayName: 'Replace Tokens'
+            inputs:
+              sourcePath: .
+              targetFilePattern: appsettings.json
+              tokenRegex: '#{(\w+)}#'
+              replaceTokenList: |
+                                Actual_Variable_Name:$(Variable_Name_Library_To_Replace)
+                                ...
+              throwExceptionifNotMapped: true
+
+          - task: Docker@0
+            displayName: 'Build .NET Core app and Docker Image'
+            inputs:
+              containerregistrytype: 'Container Registry'
+              imageName: 'containerapp$(Build.BuildId)'
+
+          - task: AmazonWebServices.aws-vsts-tools.ECRPushImage.ECRPushImage@1
+            displayName: 'Push Image: .NET Core to Amazon ECR'
+            inputs:
+              awsCredentials: <aws-credential-name>
+              regionName: <aws-region>
+              sourceImageName: 'containerapp$(Build.BuildId)'
+              repositoryName: 'aws-ecr-repository-name'
+

--- a/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-app-functions-deployment.md
+++ b/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-app-functions-deployment.md
@@ -2,7 +2,8 @@
 
 ## Pre-Deployment
 ### Install AzureDevOps Extensions
-There are two extensions should be installed before in AzureDevOps [ReplaceTokens](https://marketplace.visualstudio.com/items?itemName=citrus-andriessen.cag-replace-tokens&targetId=af056fb1-e0c2-4678-9ac3-dee687452af2&utm_source=vstsproduct&utm_medium=ExtHubManageList).
+Please install the following extension:
+AzureDevOps [ReplaceTokens](https://marketplace.visualstudio.com/items?itemName=citrus-andriessen.cag-replace-tokens&targetId=af056fb1-e0c2-4678-9ac3-dee687452af2&utm_source=vstsproduct&utm_medium=ExtHubManageList).
 
 ## .NET Core with deployment to Azure Function Apps
 ### Option 1
@@ -14,7 +15,7 @@ There are two extensions should be installed before in AzureDevOps [ReplaceToken
 6. Click on `Save`.
 
 ### Option 2
-Create a new Pipeline then choose Github `yaml`. Choose the repository from GitHub, then choose `ASP.NET Core` template, then attach to `azure-pipelines-azure-app-functions-cd.yml` template.
+Create a new Pipeline then choose `Github yaml`. Choose the repository from GitHub, then choose `ASP.NET Core` template, then attach to `azure-pipelines-azure-app-functions-cd.yml` template.
 
 ### Create Pipeline Release
 

--- a/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-app-functions-deployment.md
+++ b/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-app-functions-deployment.md
@@ -8,9 +8,9 @@ There are two extensions should be installed before in AzureDevOps [ReplaceToken
 ### Option 1
 1. Go to the Pipelines page in Azure DevOps and choose New Pipeline.
 2. Choose `Use the classic editor`.
-3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth. If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default branch then continue.
+3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth. If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default github branch then continue.
 4. On the Choose a Template page, select `ASP.NET Core` template and choose `Apply`.
-5. Choose `Triggers` tab from top and make sure to check `Enable continuous integration` under Continuous integration. (To trigger deployment process after each commit to Development branch).
+5. Choose `Triggers` tab from top and make sure to check `Enable continuous integration` under Continuous integration. (To trigger deployment process after each commit to the default github branch).
 6. Click on `Save`.
 
 ### Option 2

--- a/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-app-functions-deployment.md
+++ b/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-app-functions-deployment.md
@@ -1,4 +1,4 @@
-# Deployment using Azure DevOps
+# Azure Functions Deployment using Azure DevOps
 
 ## Pre-Deployment
 ### Install AzureDevOps Extensions

--- a/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-app-functions-deployment.md
+++ b/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-app-functions-deployment.md
@@ -1,0 +1,26 @@
+# Deployment using Azure DevOps
+
+## Pre-Deployment
+### Install AzureDevOps Extensions
+There are two extensions should be installed before in AzureDevOps [ReplaceTokens](https://marketplace.visualstudio.com/items?itemName=citrus-andriessen.cag-replace-tokens&targetId=af056fb1-e0c2-4678-9ac3-dee687452af2&utm_source=vstsproduct&utm_medium=ExtHubManageList).
+
+## .NET Core with deployment to Azure Function Apps
+### Option 1
+1. Go to the Pipelines page in Azure DevOps and choose New Pipeline.
+2. Choose `Use the classic editor`.
+3. Select GitHub as a source. (You might need to authorize Azure Pipelines with GitHub via OAuth. If so, choose "Authorize using OAuth ". This will open a new window to either log in with GitHub or grant permission to authorize Azure Pipelines with the logged in GitHub account. Granting access to the team organization where the repository is located might require an additional step: approval by an owner from that organization.) Select the target Repository and the default branch then continue.
+4. On the Choose a Template page, select `ASP.NET Core` template and choose `Apply`.
+5. Choose `Triggers` tab from top and make sure to check `Enable continuous integration` under Continuous integration. (To trigger deployment process after each commit to Development branch).
+6. Click on `Save`.
+
+### Option 2
+Create a new Pipeline then choose Github `yaml`. Choose the repository from GitHub, then choose `ASP.NET Core` template, then attach to `azure-pipelines-azure-app-functions-cd.yml` template.
+
+### Create Pipeline Release
+
+1. Navigate to `Releases` left-hand menu under `Pipelines`.
+2. Click on `New` then `New release pipeline`.
+3. For `Stages` select the template `Deploy a function to Azure Functions` then click `Apply`.
+4. Click on `Add an artifact` under `Artifacts` then Select the source which is above created pipeline.
+5. On the right top side of the added artifact click on the small icon that has the tooltip `Continuous deployment trigger` and make sure it is set to `Enabled`.
+6. Click on the blue label and configure the Azure subscription, App type and App service name.

--- a/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-pipelines-azure-app-functions-cd.yml
+++ b/best-practices/development-tools/azure/devops/deployment/azure-app-functions/azure-pipelines-azure-app-functions-cd.yml
@@ -1,0 +1,42 @@
+trigger:
+- main
+
+variables:
+  # Agent VM image name
+  vmImageName: 'windows-2019'
+
+pool:
+  name: Azure Pipelines
+  
+stages:
+- stage: Build
+  displayName: Build Production Version
+
+  jobs:
+  - job: Build
+    displayName: Build Production Version
+    pool:
+      vmImage: $(vmImageName)
+
+    steps:
+    - task: DotNetCoreCLI@2
+      displayName: 'Build project'
+      inputs:
+        projects: '**/tulare-court-azure/*.csproj'
+        arguments: '--output $(System.DefaultWorkingDirectory)/publish_output --configuration Release'
+
+    - task: ArchiveFiles@2
+      displayName: 'Archive files'
+      inputs:
+        rootFolderOrFile: 'publish_output/'
+        includeRootFolder: false
+        archiveType: zip
+        archiveFile: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+    
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Build Artifact: drop'
+      inputs:
+        PathtoPublish: $(Build.ArtifactStagingDirectory)/$(Build.BuildId).zip
+        publishLocation: Container
+        artifactName: 'drop'
+


### PR DESCRIPTION
## Changes
1. Add a documentation for using Azure DevOps with CI/CD
2. Add a documentation for using Azure DevOps to deploy azure app functions.
3. Add a documentation for using Azure DevOps to test azure app functions.
4. Add a documentation for using Azure DevOps to deploy .net Core app into AWS elastic beanstalk.

## Purpose
Have some documentations to describe how to use Azure DevOps with CI/CD.

## Learning
https://stackoverflow.com/questions/53544039/assets-file-project-assets-json-not-found-when-running-a-build-on-azure-devops
https://stackoverflow.com/questions/53727278/devops-hosted-pipeline-fail-to-build-net-core-2-2
https://docs.aws.amazon.com/vsts/latest/userguide/tutorial-eb.html
https://aws.amazon.com/blogs/devops/deploying-a-asp-net-core-web-application-to-amazon-ecs-using-an-azure-devops-pipeline/
https://medium.com/avmconsulting-blog/how-to-deploy-a-node-app-on-aws-elastic-beanstalk-with-docker-9664e5841fe
https://lightsail.aws.amazon.com/ls/docs/en_us/articles/amazon-lightsail-connecting-to-windows-server-amazon-ec2-instances
https://cmani.medium.com/access-windows-based-ec2-instances-securely-using-the-remote-desktop-gateway-rd-gateway-on-aws-f8bb8408d58e
https://docs.google.com/document/d/1_jvxKkL-1XY1ROQAOjZwQxL6lIu15v3tQ363NDOfYUE/edit#
https://us-west-1.console.aws.amazon.com/ecr/repositories/private/008036621198/ezoz-api-repository?region=us-west-1#
https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/dotnet-core-tutorial.html
https://www.youtube.com/watch?v=Ed9a0-z97js
https://www.youtube.com/watch?v=f0lMGPB10bM
https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html
https://docs.aws.amazon.com/AmazonECR/latest/userguide/getting-started-cli.html

Closes #246
