### PR TITLE
chore(qa-process): Replace shift3tech to bitwiseindustries

### DIFF
--- a/standards/qa-process.md
+++ b/standards/qa-process.md
@@ -30,7 +30,7 @@
   ![qa sprint issue](./assets/qa-process/2.png)
 
 ## Scheduling QA
-1. PM (or lead dev) sends an email to qa@shift3tech.com. If the lead dev sends the email, cc your PM on the email.
+1. PM (or lead dev) sends an email to qa@bitwiseindustries.com. If the lead dev sends the email, cc your PM on the email.
   - Provide the following details:
 ```
     - Project and client name


### PR DESCRIPTION
## Changes
1. change qa to use the correct mailing list

## Purpose
Makes sure all references to shift3tech within mail lists reference the correct parent email address.

## Approach
Changes shift3tech to bitwiseindustries.


I am actually surprised we don't have as much references to the different teams here at Bitwise. 


Closes #248
