### PR TITLE
refactor(re-branding): Re-brand Shift3 to Bitwise

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Reason for Repo
 
-- Set and maintain standards for Shift3/Bitwise projects.
-- Have a central repository where other Shift3/Bitwise members can share knowledge of best practices.
+- Set and maintain standards for Bitwise projects.
+- Have a central repository where other Bitwise members can share knowledge of best practices.
 - Have a reference point to start a new project or answer questions on different topics.
 
 [Click Here](/standards/contributing.md) to contribute!
@@ -11,11 +11,11 @@
 ## Code of Conduct
 
 1. No cussing, we're beyond that
-2. Keep the requests and issues professional and relevant to the work we're doing at Shift3/Bitwise
+2. Keep the requests and issues professional and relevant to the work we're doing at Bitwise
 3. Treat others with the same respect you would if you were talking to them in person. Don't be a jerk.
 4. Have fun and share your knowledge!
 
-## New to Shift3?
+## New to Bitwise?
 
 ### Here's what we expect you to know _before_ you write any code:
 
@@ -28,11 +28,11 @@
   - Branch off of development for features
   - Request reviews on your Pull Requests
   - Merge _reviewed_ code into development
-- [Branching](/standards/branching.md) at Shift3
-- [Commit Messages](/standards/commits.md) at Shift3
+- [Branching](/standards/branching.md) at Bitwise
+- [Commit Messages](/standards/commits.md) at Bitwise
 
 #### Code Versioning
-- [Shift3 SemVer](/standards/code-versioning.md)
+- [Bitwise SemVer](/standards/code-versioning.md)
 
 #### Project Setup
 - [Using Github Projects](/standards/project-setup.md) to communicate progress
@@ -40,7 +40,7 @@
 
 #### Code Review
 
-- [Code Review](/standards/code-reviews.md#process) process at Shift3
+- [Code Review](/standards/code-reviews.md#process) process at Bitwise
   - [Code Review Slides](https://docs.google.com/presentation/d/16S4qMbwdBT2u9c3-djHhSRXoUUytf12HGxloWh4y4cE/edit#slide=id.g35f391192_00)
 - [Acceptance Testing](/standards/acceptance-testing.md)
 - [Bug Reporting](/standards/bug-reporting.md)
@@ -83,7 +83,7 @@ Using Chocolatey has several advantages:
 
 - AWS is our primary platform for deployment (staging and production) so you should familiarize yourself with their [JavaScript SDK](https://aws.amazon.com/sdk-for-node-js/) and [whitepapers](https://aws.amazon.com/whitepapers/).
 
-##### Shift3 Standards & Practices Meetings:
+##### Bitwise Standards & Practices Meetings:
 
 ###### Meetings are now split into two types:
 
@@ -92,17 +92,17 @@ Using Chocolatey has several advantages:
 
 ##### Frontend Masters:
 
-- Shift3's main online teaching tool is [Frontend Masters](https://frontendmasters.com/). They have courses on all of the platforms we employ at Shift3, and you should take advantage of as many as possible.
+- Bitwise main online teaching tool is [Frontend Masters](https://frontendmasters.com/). They have courses on all of the platforms we employ at Bitwise, and you should take advantage of as many as possible.
 
 ##### WebStorm:
 
-- If you prefer to use JetBrains' tooling, Shift3 provides us with WebStorm Suite for free. We also use [Visual Studio](https://visualstudio.microsoft.com/) and [Visual Studio Code](https://code.visualstudio.com/).
+- If you prefer to use JetBrains' tooling, Bitwise provides us with WebStorm Suite for free. We also use [Visual Studio](https://visualstudio.microsoft.com/) and [Visual Studio Code](https://code.visualstudio.com/).
 
 ##### Photoshop:
 
-- If your job entails design work, you will need to get access to the Shift3 Adobe Photoshop license.
+- If your job entails design work, you will need to get access to the Bitwise Adobe Photoshop license.
 
-## Contributing to Shift3
+## Contributing to Bitwise
 
 ### You are expected to contribute _something_ to our processes. You can do this in many different ways, such as leading a S&P meeting, writing up a markdown sheet for this repository on a topic you are passionate about, leading a workshop, or posting discussion topics in Bitwise's #shift-3-technical-discussions channel.
 

--- a/best-practices/development-tools/accessibility/README.md
+++ b/best-practices/development-tools/accessibility/README.md
@@ -14,7 +14,7 @@ While this may mean that there is no standard for non-government sites, that doe
 
 ## WCAG 2.1 Summary
 
-Shift3 would recommend giving the full standard a read.The criteria falls into four critera: **Perceivable**, **Operable**, **Understandable** and **Robust**. There are three standards, A, AA, and AAA. Most compliance requirements ask for level AA compliance.
+Bitwise would recommend giving the full standard a read.The criteria falls into four critera: **Perceivable**, **Operable**, **Understandable** and **Robust**. There are three standards, A, AA, and AAA. Most compliance requirements ask for level AA compliance.
 
 ### Perceivable
 

--- a/best-practices/native/react-native/README.md
+++ b/best-practices/native/react-native/README.md
@@ -10,7 +10,7 @@ There are typically 2 options for React Native development:
         a. It has an excellent native API for device features that is intuitive and easy to use  
         b. It is the quickest way to get started  
         c. Expo uses their servers to ensure stability of your builds and to allow you to employ push notifications easily  
-    * You should read the [caveats](https://facebook.github.io/react-native/docs/getting-started#caveats) on using Expo, but for Shift3, the main drawbacks are:
+    * You should read the [caveats](https://facebook.github.io/react-native/docs/getting-started#caveats) on using Expo, but for Bitwise, the main drawbacks are:
         1. If your project will need background support (the app should keep running when not in focus) DO NOT use Expo 
 2. [Native Code](startup/native-code.md)
     * This is a more difficult project to start up, but you have more flexibility once it's started than with Expo.
@@ -19,7 +19,7 @@ There are typically 2 options for React Native development:
 ## Then what?
 - After you have started up your project, take a look at our [common components](common-components/README.md) for some base starting points.  
 
-- Take a look at how we handle React Native [deployment](deployment/README.md) at Shift3.
+- Take a look at how we handle React Native [deployment](deployment/README.md) at Bitwise.
 
 
 

--- a/best-practices/native/react-native/rn-by-example/README.md
+++ b/best-practices/native/react-native/rn-by-example/README.md
@@ -6,7 +6,7 @@ RN >= 0.57
 
 Starting a new React Native project? We've put together a great starting point for your app so you can get started as fast as possible, without the fuss.
 
-[Shift3 React Native Boilerplate App](https://github.com/Shift3/rn-by-example)
+[Bitwise React Native Boilerplate App](https://github.com/Shift3/rn-by-example)
 
 ## Lessons
 

--- a/best-practices/native/react-native/startup/native-code.md
+++ b/best-practices/native/react-native/startup/native-code.md
@@ -1,6 +1,6 @@
 # React Native Code Start up Guide
 
 1. [Go here](https://facebook.github.io/react-native/docs/getting-started.html) and make sure you have selected the `Building Projects with Native Code` tab. Follow the CLI installation instructions for your OS.
-2. Take advantage of Shift3's [Frontend Masters](https://frontendmasters.com/courses/react-native/) course on React Native. This will get you familiar with the basics of React Native's design patters, state management, and common best practices.
+2. Take advantage of Bitwise's [Frontend Masters](https://frontendmasters.com/courses/react-native/) course on React Native. This will get you familiar with the basics of React Native's design patters, state management, and common best practices.
 3. Install [Prop Types](https://github.com/facebook/prop-types) library to ensure type checking on your custom component props.
 4. Take a look at our [common components](../common-components/README.md) for React Native and use what you need. Contribute some of your own reusable components if you have some!

--- a/best-practices/native/xamarin/README.md
+++ b/best-practices/native/xamarin/README.md
@@ -2,7 +2,7 @@
 So, you think you can "Xam?"  I don't know if you think that you can!  At any rate, I'm here to help you and when that doesn't work... to tell you what to do.
 
 ## Follow C# Best Practices and Then Some
-Xamarin projects employ C#.  As such, you should follow Shift3's best practices for C#.  Consider K&R style and expression body syntax when possible to keep code LOC as readable and *concise* as possible.  Don't make us read three lines for one expression.
+Xamarin projects employ C#.  As such, you should follow Bitwise's best practices for C#.  Consider K&R style and expression body syntax when possible to keep code LOC as readable and *concise* as possible.  Don't make us read three lines for one expression.
 
 [Stack Overflow - Visual Studio and K&R](https://stackoverflow.com/questions/3048800/how-can-i-set-visual-studio-to-use-kr-style-bracketing/)
 
@@ -27,7 +27,7 @@ Xamarin Shell has a glut of benefits.  URL-ish, abstracted navigation is one of 
 Note that this technology is new to Xamarin Forms but do indeed attempt to use it unless you need a completely custom UI and custom flyout menu.  There are still some small growing pains.  For example, as of 09/11/2019 they still don't have a bindable, XAML-based back-button override that works without crashing.  Freunlaven!
 
 ## Consider Using Prism
-Prism is a library that also provides a navigation service, simplified MVVM, dependency injection and simplified EventToCommand behavior.  It may be a good fit for your Xamarin application and is used in at least one (as of writing this) Shift3 project, [FrontDeskKiosk](https://github.com/Shift3/fusd-front-desk-kiosk).  Xamarin Shell steals a bit of thunder from Prism, however, so it may be less useful if Shell is employed.
+Prism is a library that also provides a navigation service, simplified MVVM, dependency injection and simplified EventToCommand behavior.  It may be a good fit for your Xamarin application and is used in at least one (as of writing this) Bitwise project, [FrontDeskKiosk](https://github.com/Shift3/fusd-front-desk-kiosk).  Xamarin Shell steals a bit of thunder from Prism, however, so it may be less useful if Shell is employed.
 
 [Prism for WPF and Xamarin](http://prismlibrary.github.io/docs/)
 

--- a/best-practices/server-side/security/README.md
+++ b/best-practices/server-side/security/README.md
@@ -4,4 +4,4 @@
 
 [JWT](jwt/README.md) on Node Servers
 
-[Permissions](permissions/README.md) the Shift3 Way
+[Permissions](permissions/README.md) the Bitwise Way

--- a/presentations/README.md
+++ b/presentations/README.md
@@ -6,7 +6,7 @@
 
 Our intrepid developers have compiled a wealth of knowledge about the technology we work with and the way we use it. The spreadsheet below is a compilation of slide decks and videos (if available) of Standards and Practices presentations given. These are a great resource if you're looking for tips and tricks, or if you need to prepare yourself for technology you haven't used before!
 
-[Shift3 Technologies Slide Decks](https://docs.google.com/spreadsheets/d/1wlaAs7a4a0mDrMCMZeE7UI1gGeqv36yCw-hiR0e4TzU/edit?usp=sharing)
+[Bitwise Technologies Slide Decks](https://docs.google.com/spreadsheets/d/1wlaAs7a4a0mDrMCMZeE7UI1gGeqv36yCw-hiR0e4TzU/edit?usp=sharing)
 
 **If you don't already have access to this (not a member of the Bitwise group on Google, for example), request access!**
 

--- a/standards/README.md
+++ b/standards/README.md
@@ -1,8 +1,8 @@
 # Standards
 
-This section describes Shift3 standards to be applied to all projects. Code reviews should be used to identify when these standards are not applied.
+This section describes Bitwise standards to be applied to all projects. Code reviews should be used to identify when these standards are not applied.
 
-## How we build software at Shift3
+## How we build software at Bitwise
 
 ### Setting up a Repository
 
@@ -30,11 +30,11 @@ This section describes Shift3 standards to be applied to all projects. Code revi
 
 #### [Managing Branches](branching.md)
 
-- Explanation of Shift3 branch structure
-- Git flow at Shift3
+- Explanation of Bitwise branch structure
+- Git flow at Bitwise
 - List of Git commands
 
-#### [Commit Messages the Shift3/Karma way](commits.md)
+#### [Commit Messages the Bitwise/Karma way](commits.md)
 
 - Commit message guidelines
 - How to format commit messages
@@ -82,4 +82,4 @@ This section describes Shift3 standards to be applied to all projects. Code revi
 
 #### [Contributing](contributing.md)
 
-- How to contribute to the Shift3 Standards & Practices Repository
+- How to contribute to the Bitwise Standards & Practices Repository

--- a/standards/acceptance-testing.md
+++ b/standards/acceptance-testing.md
@@ -2,7 +2,7 @@
 
 ## What is Acceptance Testing
 
-- At Shift3, Acceptance Testing is testing to simulate real world end user scenarios. It is primarily handled by the QA team, who test the project from the same perspective as a user. They test on staging and production environments (not local ones), and without the inside and technical perspective of the developers who built the project.
+- At Bitwise, Acceptance Testing is testing to simulate real world end user scenarios. It is primarily handled by the QA team, who test the project from the same perspective as a user. They test on staging and production environments (not local ones), and without the inside and technical perspective of the developers who built the project.
 
 ## Purpose
 

--- a/standards/code-reviews.md
+++ b/standards/code-reviews.md
@@ -1,6 +1,6 @@
 # Code Reviews
 
-### The purposes of code review at Shift3 (and in the industry generally) are:
+### The purposes of code review at Bitwise (and in the industry generally) are:
 1. Teachability:
     * They help you remain teachable
     * They allow us to learn from each other's experience. What developer _doesn't_ want to keep learning?
@@ -15,7 +15,7 @@
 ## Process
 
 ### Author
-* At Shift3 we have a simple code review process
+* At Bitwise we have a simple code review process
 
 1. Before you create your Pull Request or tag anyone in anything, double check that you're ready
 

--- a/standards/code-versioning.md
+++ b/standards/code-versioning.md
@@ -5,7 +5,7 @@
 -   [Tagging](https://git-scm.com/book/en/v2/Git-Basics-Tagging) is a simple, easy way to keep track of your code at a certain point in time. Some instances where this becomes useful are:
     -   Client-facing deliverables such as milestones, UAT, or production launch/release
     -   Internal-facing code at a point that you or your team wants to demarcate as important
-    -   Versioning of your code (as a default, Shift3 follows SemVer)
+    -   Versioning of your code (as a default, Bitwise follows SemVer)
 
 ## [SemVer](https://semver.org/) Basics:
 
@@ -30,7 +30,7 @@
 *   Initial development (so most of our lives) should be treated as 0.x.x so as to indicate that there is no release as yet.
     -   Generally, any software with a major version of 0 should be treated as unstable.
 
-## Why should Shift3 care?
+## Why should Bitwise care?
 
 This should be self-evident: more maintainable code makes our jobs easier! Tagging does the following things
 
@@ -104,4 +104,4 @@ _Releases are useful for marking a client-facing milestones in your code's histo
 [SemVer Main Docs](https://semver.org/)  
 [SemVer Breakdown](https://www.jvandemo.com/a-simple-guide-to-semantic-versioning/)  
 [Convincing Argument for SemVer](https://www.sitepoint.com/semantic-versioning-why-you-should-using/)  
-[Slides for Tagging at Shift3](https://docs.google.com/presentation/d/1mZ35fZ7GhIBcCAPzeAXXAprcQZUv4WL-BELp9tEsFE8/edit?usp=sharing)
+[Slides for Tagging at Bitwise](https://docs.google.com/presentation/d/1mZ35fZ7GhIBcCAPzeAXXAprcQZUv4WL-BELp9tEsFE8/edit?usp=sharing)

--- a/standards/commits.md
+++ b/standards/commits.md
@@ -1,6 +1,6 @@
 # Git Commit Messages
 
-## Shift3's convention for how to structure, write, and use your commits  
+## Bitwise's convention for how to structure, write, and use your commits  
  _([reference](http://karma-runner.github.io/1.0/dev/git-commit-msg.html))_  
 
 

--- a/standards/contributing.md
+++ b/standards/contributing.md
@@ -1,4 +1,4 @@
-# Contributing to the Shift3 Standards & Practices Repository
+# Contributing to the Bitwise Standards & Practices Repository
 
 ### If you want to contribute, here's how:
 
@@ -8,7 +8,7 @@
   - If you need to submit an issue, make sure the name is descriptive but brief and add a comment describing the change.
     > If you can't think of a way the change will benefit the team, consider looking over our [open issues](https://github.com/Shift3/standards-and-practices/issues?q=is%3Aopen+is%3Aissue+label%3A%22Good+First+Contribution%22) for something you can contribute that the team needs right now.
 
-2. Clone the repository and create a new branch following the [Shift3 guideline](/standards/branching.md)
+2. Clone the repository and create a new branch following the [Bitwise guideline](/standards/branching.md)
 3. Inside the appropriate folder, write out a clear, concise .md file on your topic of choice, or edit one that needs to be updated. Make sure you use the Markdown Cheatsheet linked below as a guideline.
    ###### Add a link to your topic in your topic's parent folder's README<span>.md file.
 4. Push your code and create a PR, assigning at least two admins to review.

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -1,9 +1,9 @@
 # Git Commands
 Git is a distributed version-control system for tracking changes in source code during software development. It is designed for coordinating work among programmers, but it can be used to track changes in any set of files. Its goals include speed, data integrity, and support for distributed, non-linear workflows.
 
-At Shift3, we use git for a majority of our software projects.
+At Bitwise, we use git for a majority of our software projects.
 
-## Shift3 Git specific resources
+## Bitwise Git specific resources
 1. [Commits](commits.md)
 2. [Branching](branching.md)
 3. [Code Versioning](code-versioning.md)

--- a/standards/project-setup.md
+++ b/standards/project-setup.md
@@ -14,7 +14,7 @@
     * Create a note for each of your epics/project boards  
     * Make a markdown link in each note to the corresponding project board  
   3. Open as many issues as you need to complete each epic.  
-    Remember: follow Shift3's [branching guide](branching.md) when you start working on these issues.
+    Remember: follow Bitwise's [branching guide](branching.md) when you start working on these issues.
 
 ### Example from Shift3:
   [Sinclair Project Boards](https://github.com/Shift3/sinclair-scanner-application/projects)

--- a/standards/qa-process.md
+++ b/standards/qa-process.md
@@ -2,7 +2,7 @@
 ## Project-Under-Test is Prepared
 - For mobile apps: Application is made available on Testflight or loaded onto test devices. Application should be deployed to the Client’s Apple and Google accounts.
 - For web apps: Site is deployed to a staging server. Staging server should live on clients hosting provider.
-- Developer or PM prepares an Acceptance Test per the Shift3 guidelines.
+- Developer or PM prepares an Acceptance Test per the Bitwise guidelines.
 - PM or Lead Dev will create a milestone for the QA Sprint with:
   - Milestone deadline
   - Short project or feature description

--- a/standards/readme-guidelines.md
+++ b/standards/readme-guidelines.md
@@ -1,6 +1,6 @@
 # Readme Guidelines
 
-All Shift3 projects should include a readme file with the following sections:
+All Bitwise projects should include a readme file with the following sections:
 - Project Name and Description
 - Project Requirements
 - Project Setup / Build Instructions

--- a/workshops/README.md
+++ b/workshops/README.md
@@ -2,8 +2,8 @@
 
 ## Slide Decks and Videos
 
-These workshops provide continuous training and education for the development team. You can expect a hands-on learning experience so bring your computer, your brain, and lots of coffee. We want every developer to be involved, so please coordinate with your PM to adjust schedules as necessary. Before the workshop we will share any resources or setup instructions required to participate. The spreadsheet below is a compilation of repositories and videos (if available) of Standards and Practices workshops given. 
+These workshops provide continuous training and education for the development team. You can expect a hands-on learning experience so bring your computer, your brain, and lots of coffee. We want every developer to be involved, so please coordinate with your PM to adjust schedules as necessary. Before the workshop we will share any resources or setup instructions required to participate. The spreadsheet below is a compilation of repositories and videos (if available) of Standards and Practices workshops given.
 
-[Shift3 Technologies Workshops](https://docs.google.com/spreadsheets/d/1PQmc5lWzHUeYE3eoDoX3lwgAfavfr1XG4bRb_1y_1gU/edit?usp=sharing)
+[Bitwise Technologies Workshops](https://docs.google.com/spreadsheets/d/1PQmc5lWzHUeYE3eoDoX3lwgAfavfr1XG4bRb_1y_1gU/edit?usp=sharing)
 
 **If you don't already have access to this (not a member of the Bitwise group on Google, for example), request access!**


### PR DESCRIPTION
## Changes
1. Rebranded Shift3 to Bitwise

## Purpose
Removed Shift3 references where it made sense to do so.

## Approach
Replaced Shift3 verbiage with Bitwise. Some of the old projects are still branded as Shift3.

## Learning
After looking at all the older pages, its apparent we should take a look at some of the older resources and projects. 

Closes #251
