### PR TITLE
docs(standards): fix QA Process link

### DIFF
--- a/standards/README.md
+++ b/standards/README.md
@@ -63,7 +63,7 @@ This section describes Bitwise standards to be applied to all projects. Code rev
 - GitHub labels for Issue management
 - Bug reporting template
 
-#### [QA Process](../processes/qa-process.md)
+#### [QA Process](qa-process.md)
 
 - How to setup your repository for a QA sprint
 - How to schedule QA time


### PR DESCRIPTION
## Changes
1. Change broken link for QA Process

## Purpose
QA Process link redirected to 404, did not redirect to readme

## Learning
This was to practice pull requests per the automated onboarding email.

Also, I know we are supposed to merge to the development branch, but this repo doesn't have one (which I think makes sense) so I chose main.

closes #264 