### PR TITLE
Fixed Re-Direct Link for QA Process

### DIFF
--- a/standards/README.md
+++ b/standards/README.md
@@ -63,7 +63,7 @@ This section describes Bitwise standards to be applied to all projects. Code rev
 - GitHub labels for Issue management
 - Bug reporting template
 
-#### [QA Process](../processes/qa-process.md)
+#### [QA Process](../standards/qa-process.md)
 
 - How to setup your repository for a QA sprint
 - How to schedule QA time


### PR DESCRIPTION
S.H
<GitHub Issue #264>
Fixed Re-Direct Bug

## Changes
_List Changes Introduced by this PR_
1. https://github.com/Shift3/standards-and-practices/blob/main/processes/qa-process.md

Expected Behavior:
Clicking QA Process using the below link, and it should re direct to QA Process
Go to https://github.com/Shift3/standards-and-practices/tree/main/standards#qa-process

Steps to Reproduce Bug.
1: Go tohttps://github.com/Shift3/standards-and-practices/tree/main/standards#qa-process
2. Click on QA Process

Steps to Resolve Bug.
1: Checked to see where link re-directed to
2: Compared the current redirect link
https://github.com/Shift3/standards-and-practices/blob/main/processes/qa-process.md

3: What the actual link should be
https://github.com/Shift3/standards-and-practices/blob/main/standards/qa-process.md

Steps taken to check if this resolved issue.
1: Made sure the actual link, actually went to the correct url.

Closes #264 
