### PR TITLE
fix(link-check): remove awesome_bot github whitelist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,4 +7,4 @@ jobs:
       - checkout
       - run: bundle install
       - run: bundle exec danger --verbose
-      - run: bundle exec awesome_bot --allow-redirect --allow-dupe -w awesome_bot --allow-redirect --allow-dupe -w https://github.com/Shift3,regexr,127.0.0.1 `find . -name "*.md"`
+      - run: bundle exec awesome_bot --allow-redirect --allow-dupe -w awesome_bot --allow-redirect --allow-dupe -w regexr,127.0.0.1 `find . -name "*.md"`

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,4 +7,4 @@ jobs:
       - checkout
       - run: bundle install
       - run: bundle exec danger --verbose
-      - run: bundle exec awesome_bot --allow-redirect --allow-dupe -w awesome_bot --allow-redirect --allow-dupe -w regexr,127.0.0.1 `find . -name "*.md"`
+      - run: bundle exec awesome_bot --allow-redirect --allow-dupe -w awesome_bot --allow-redirect --allow-dupe -w https://github.com/Shift3/ifg/compare/v0.4.0...v0.5.0,https://github.com/Shift3/sinclair-scanner-application,https://github.com/Shift3/sinclair-scanner-application/pull/137,https://github.com/Shift3/FUSDMonitoringAppXamarin,https://github.com/Shift3/rn-by-example,https://github.com/Shift3/fusd-front-desk-kiosk,regexr,https://github.com/Shift3/bw-project-status,https://github.com/Shift3/Aerostar,https://github.com/Shift3/sundial-mobile-app,127.0.0.1 `find . -name "*.md"`


### PR DESCRIPTION
## Changes
1. Remove shift3 blanket blocklist
2. Replace with project/link specific Shift3 url allowlist

## Purpose
Fix issue where internal public facing README links were not linked to an existing page.  

## Approach
By being very specific with what pages are being blocked from awesome_bot, we reduce the number of possible false positives. 

## Pre-Testing TODOs
Pull down the repo.

## Testing Steps
run `bundle exec awesome_bot --allow-redirect --allow-dupe -w awesome_bot --allow-redirect --allow-dupe -w https://github.com/Shift3/ifg/compare/v0.4.0...v0.5.0,https://github.com/Shift3/sinclair-scanner-application,https://github.com/Shift3/sinclair-scanner-application/pull/137,https://github.com/Shift3/FUSDMonitoringAppXamarin,https://github.com/Shift3/rn-by-example,https://github.com/Shift3/fusd-front-desk-kiosk,regexr,https://github.com/Shift3/bw-project-status,https://github.com/Shift3/Aerostar,https://github.com/Shift3/sundial-mobile-app,127.0.0.1 `find . -name "*.md"` or simply see the CircleCI script run.

Closes #267
