### PR TITLE
feat(README): Internal Resources for help

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Using Chocolatey has several advantages:
 - If your job entails design work, you will need to get access to the Bitwise Adobe Photoshop license.
 
 ## Need Help?
-Getting stuck is a natual part of development and happends to the best of us. Its better to reach out than to stay silent and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
+Getting stuck is a natual part of development and happends to the best of us. It's better to reach out than to stay silent and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
 
 ##### Slack channels:
 1. *bwtc-technical-discussions* - Great place for technical questions that involve some code. 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ Using Chocolatey has several advantages:
 
 - If your job entails design work, you will need to get access to the Bitwise Adobe Photoshop license.
 
+## Need Help?
+Getting stuck is a natual part of development and happends to the best of us. Its better to reach out than to stay silent and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
+
+##### Slack channels:
+1. *bwtc-technical-discussions* - Great place for technical questions that involve some code. 
+2. *Your team channel* - When you start a project, you will be added to a private team channel. Feel free to ask your questions there! Your team lead may be able to help you through your blocker.
+
 ## Contributing to Bitwise
 
 ### You are expected to contribute _something_ to our processes. You can do this in many different ways, such as leading a BW Developer Connect meeting, writing up a markdown sheet for this repository on a topic you are passionate about, leading a workshop, or posting discussion topics in Bitwise's #shift-3-technical-discussions channel.


### PR DESCRIPTION
## Changes
1. Add in slack channels and other references for help with blockers.

## Purpose
Make developers aware of our slack channels that can help them out. 

## Approach
Add in the start of the basic slack channels that we have available within the org. 

## Learning
If anyone knows of some good BW specific slack channels, resources, outreach comment below and we can add it to the list! I can see this becoming another page eventually. 

Closes #273
