### PR TITLE
docs(commits): update with commit messages information

### DIFF
--- a/standards/commits.md
+++ b/standards/commits.md
@@ -18,7 +18,16 @@ There are [many conventions](https://github.com/conventional-changelog/commitlin
 
 ### Your commit messages should be formatted as follows:
 
+Short message example:
+
 `type(scope):subject`
+
+Long message example:
+```
+type(scope):subject
+(blank line)
+body
+```
 
 **Type**: Select one of the following 8 commit types. These are your _only_ options for commit type:
 
@@ -33,9 +42,9 @@ There are [many conventions](https://github.com/conventional-changelog/commitlin
 
 **Scope**: Narrow the scope of the commit to a one or two word description in parentheses
 
-**Message Subject**: Favor imperative mood, present tense, active voice, and start with verbs. Don't use a period at the end. Think of it as a newspaper headline.
+**Subject**: Favor imperative mood, present tense, active voice, and start with verbs. Don't use a period at the end. Think of it as a newspaper headline.
 
-**Message Body** (optional): If necessary, provide additional context that can help other developers in the future. This is normally unnecessary but some use cases are:
+**Body** (optional): If necessary, provide additional context that can help other developers in the future. This is normally unnecessary but some use cases are:
 
 - If the commit contains a new package you've added to the project
 - If the commit contains a change to your build that you need to notate

--- a/standards/commits.md
+++ b/standards/commits.md
@@ -18,18 +18,18 @@ There are [many conventions](https://github.com/conventional-changelog/commitlin
 
 ### Your commit messages should be formatted as follows:
 
-Short message example:
+Short message example (`git commit -m "..."`):
 
 `type(scope):subject`
 
-Long message example:
+Long message example (`git commit`):
 ```
 type(scope):subject
 (blank line)
 body
 ```
 
-**Type**: Select one of the following 8 commit types. These are your _only_ options for commit type:
+`type`: Select one of the following 8 commit types. These are your _only_ options for commit type:
 
 - **_feat_**: A new feature for the application user. Rolling out a new module, new piece of functionality, etc.
 - **_fix_**: Bug fix to your production code. Dealing with GH Issues, fixing a bug, etc.
@@ -40,11 +40,11 @@ body
 - **_chore_**: Updating gulp, webpack, package.json files. This is developer-facing _only_.
 - **_workaround_**: Temporary fix until a more robust solution is found or until other factors are resolved.
 
-**Scope**: Narrow the scope of the commit to a one or two word description in parentheses
+`scope`: Narrow the scope of the commit to a one or two word description in parentheses
 
-**Subject**: Favor imperative mood, present tense, active voice, and start with verbs. Don't use a period at the end. Think of it as a newspaper headline.
+`subject`: Favor imperative mood, present tense, active voice, and start with verbs. Don't use a period at the end. Think of it as a newspaper headline.
 
-**Body** (optional): If necessary, provide additional context that can help other developers in the future. This is normally unnecessary but some use cases are:
+`body` (optional): If necessary, provide additional context that can help other developers in the future. This is normally unnecessary but some use cases are:
 
 - If the commit contains a new package you've added to the project
 - If the commit contains a change to your build that you need to notate

--- a/standards/commits.md
+++ b/standards/commits.md
@@ -20,7 +20,7 @@ There are [many conventions](https://github.com/conventional-changelog/commitlin
 
 `type(scope):subject`
 
-Commit **Type**: Select one of the following 8 commit types. These are your _only_ options for commit type:
+**Type**: Select one of the following 8 commit types. These are your _only_ options for commit type:
 
 - **_feat_**: A new feature for the application user. Rolling out a new module, new piece of functionality, etc.
 - **_fix_**: Bug fix to your production code. Dealing with GH Issues, fixing a bug, etc.
@@ -31,14 +31,15 @@ Commit **Type**: Select one of the following 8 commit types. These are your _onl
 - **_chore_**: Updating gulp, webpack, package.json files. This is developer-facing _only_.
 - **_workaround_**: Temporary fix until a more robust solution is found or until other factors are resolved.
 
-Commit **Scope**: Narrow the scope of the commit to a one or two word description in parentheses
+**Scope**: Narrow the scope of the commit to a one or two word description in parentheses
 
-Message **Subject**: Favor imperative mood, present tense, active voice, and start with verbs. Don't use a period at the end. Think of it as a newspaper headline.
+**Message Subject**: Favor imperative mood, present tense, active voice, and start with verbs. Don't use a period at the end. Think of it as a newspaper headline.
 
-Message **Body**: If necessary, write a short sentence detailing pertinent information for other developers. This is normally unnecessary but some use cases are:
+**Message Body** (optional): If necessary, provide additional context that can help other developers in the future. This is normally unnecessary but some use cases are:
 
 - If the commit contains a new package you've added to the project
 - If the commit contains a change to your build that you need to notate
+- If the commit includes changes that would benefit from an explanation and from additional context.
 - If the commit is the last in a series that will become a Pull Request and you want to communicate something to your senior developer.
 
 ## Examples
@@ -56,7 +57,7 @@ There are at least two _scopes_ being dealt with here: the **app.component** sco
 
   > `git commit -m "refactor(app-component): import user service and add routes"`
 
-        _Now you have 1 commit, dedicated to the **app.component** scope._
+  _Now you have 1 commit, dedicated to the **app.component** scope._
 
 - Next, `git add` the login files and create a new commit message for these files.
   > `git commit -m "feat(login): create/setup"`
@@ -69,4 +70,3 @@ There are many tools available to help you ***enforce*** the commit convention r
 One example, if you're using npm/package.json in your project, you can install [commitlint](https://github.com/conventional-changelog/commitlint) package. This adds a commit message linter to your command line. There are many plugins available for it with pre-configured convention rules, you can check them out [here](https://github.com/conventional-changelog/commitlint#shared-configuration). If those don't meet your needs you can extend them using a commitlint [configuration file](https://github.com/conventional-changelog/commitlint#config). You can then add the commitlint as a hook using Husky ([directions here](https://github.com/conventional-changelog/commitlint#getting-started)). After you set that up every time you try to run `git commit` it will first pass your commit message through the linter and either it will succeed or get rejected with a violation reason if it doesn't comply with the rules.
 
 *If you find any other tools that you would like to share please open a PR.*
-

--- a/standards/commits.md
+++ b/standards/commits.md
@@ -1,52 +1,72 @@
-# Git Commit Messages
+# Bitwise's convention on how to structure, write, and use commit messages
 
-## Bitwise's convention for how to structure, write, and use your commits  
- _([reference](http://karma-runner.github.io/1.0/dev/git-commit-msg.html))_  
+Using a convention for commit messages has several benefits. For one, it makes it easier to find individual commits. It also forces us to keep our commits small enough to be able easily reason what they're doing. And lastly to be able to revert small chunks of code if needed.
 
+## Git Commit Messages Conventions
 
-### Guidelines:
+There are [many conventions](https://github.com/conventional-changelog/commitlint#shared-configuration) available, many follow a close resemblance to the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
 
- * Each commit should contain files that all pertain to the same _scope_ 
+👍 **The one we use at Bitwise is based on the [Karma Runner](http://karma-runner.github.io/1.0/dev/git-commit-msg.html) project.** Please review it.
 
- * If you have changed multiple files that apply to different scopes, add and commit them separately  
+## Guidelines:
 
- * Make your messages as direct and succinct as possible
+- Each commit should contain files that all pertain to the same _scope_
+- If you have changed multiple files that apply to different scopes, add and commit them separately
+- Make your messages as direct and succinct as possible
 
-### Format:
+## Format
 
- * **Your commit messages should be formatted as follows:** 
-    >**type(scope):body**  
+### Your commit messages should be formatted as follows:
 
-    1. Commit **Type**: Select one of the following 8 commit types. These are your _only_ options for commit type:
-        * *feat* : A new feature for the application user. Rolling out a new module, new piece of functionality, etc. 
-        * *fix* : Bug fix to your production code. Dealing with GH Issues, fixing a bug, etc.
-        * *docs* : Changes to your documentation. Adding a comment, editing a comment, changing README.md files, etc.
-        * *style* : Changes to your code formatting. _This does **not** address CSS styling_ but rather the style of your code. Reformatting, adding semi-colons, etc.
-        * *refactor* : Refactor to production code. Upgrading a package and changing your code to meet the new demands, changing a **let** or a **const** name, etc.
-        * *test* :  All things that apply to unit testing. Creating tests, refactoring tests, etc. No changes to production code occur.
-        * *chore* : Updating gulp, webpack, package.json files. This is developer-facing _only_.
-        * *workaround* : Temporary fix until a more robust solution is found or until other factors are resolved.
-    2. Commit **Scope**: Narrow the scope of the commit to a one or two word description in parentheses
-    
-    3. Message **Body**: If necessary, write a short sentence detailing pertinent information for other developers. This is normally unnecessary but some use cases are:
+`type(scope):subject`
 
-        * If the commit contains a new package you've added to the project
-        * If the commit contains a change to your build that you need to notate
-        * If the commit is the last in a series that will become a Pull Request and you want to communicate something to your senior developer.
+Commit **Type**: Select one of the following 8 commit types. These are your _only_ options for commit type:
 
-### Examples: 
-  * Say you have changed four files: 
-    
-    > app.component.ts
-    > app.router.ts
-    > login.component.ts
-    > login.component.scss
+- **_feat_**: A new feature for the application user. Rolling out a new module, new piece of functionality, etc.
+- **_fix_**: Bug fix to your production code. Dealing with GH Issues, fixing a bug, etc.
+- **_docs_**: Changes to your documentation. Adding a comment, editing a comment, changing README.md files, etc.
+- **_style_**: Changes to your code formatting. _This does **not** address CSS styling_ but rather the style of your code. Reformatting, adding semi-colons, etc.
+- **_refactor_**: Refactor to production code. Upgrading a package and changing your code to meet the new demands, changing a **let** or a **const** name, etc.
+- **_test_**: All things that apply to unit testing. Creating tests, refactoring tests, etc. No changes to production code occur.
+- **_chore_**: Updating gulp, webpack, package.json files. This is developer-facing _only_.
+- **_workaround_**: Temporary fix until a more robust solution is found or until other factors are resolved.
 
-  * There are at least two _scopes_ being dealt with here: the **app.component** scope and the **login.component** scope.
-    * `git add` the  **app.component.ts** and the **app.router.ts** and create a commit for those files. 
-        > `git commit -m "refactor(app-component): import user service and add routes"`        
-            _Now you have 1 commit, dedicated to the **app.component** scope._  
-    
-    * Next, `git add` the login files and create a new commit message for these files.   
-        > `git commit -m "feat(login): create/setup"`  
-            _Note that this message is less verbose because it isnt necessary to add detail_
+Commit **Scope**: Narrow the scope of the commit to a one or two word description in parentheses
+
+Message **Subject**: Favor imperative mood, present tense, active voice, and start with verbs. Don't use a period at the end. Think of it as a newspaper headline.
+
+Message **Body**: If necessary, write a short sentence detailing pertinent information for other developers. This is normally unnecessary but some use cases are:
+
+- If the commit contains a new package you've added to the project
+- If the commit contains a change to your build that you need to notate
+- If the commit is the last in a series that will become a Pull Request and you want to communicate something to your senior developer.
+
+## Examples
+
+Say you have changed four files:
+
+> app.component.ts
+> app.router.ts
+> login.component.ts
+> login.component.scss
+
+There are at least two _scopes_ being dealt with here: the **app.component** scope and the **login.component** scope.
+
+- `git add` the **app.component.ts** and the **app.router.ts** and create a commit for those files.
+
+  > `git commit -m "refactor(app-component): import user service and add routes"`
+
+        _Now you have 1 commit, dedicated to the **app.component** scope._
+
+- Next, `git add` the login files and create a new commit message for these files.
+  > `git commit -m "feat(login): create/setup"`
+        _Note that this message is less verbose because it isnt necessary to add detail_
+
+## Automation Tools 🛠
+
+There are many tools available to help you ***enforce*** the commit convention rules via git hooks. This way you can always be sure that your commit will satisfy the rules before they're added to the history.
+
+One example, if you're using npm/package.json in your project, you can install [commitlint](https://github.com/conventional-changelog/commitlint) package. This adds a commit message linter to your command line. There are many plugins available for it with pre-configured convention rules, you can check them out [here](https://github.com/conventional-changelog/commitlint#shared-configuration). If those don't meet your needs you can extend them using a commitlint [configuration file](https://github.com/conventional-changelog/commitlint#config). You can then add the commitlint as a hook using Husky ([directions here](https://github.com/conventional-changelog/commitlint#getting-started)). After you set that up every time you try to run `git commit` it will first pass your commit message through the linter and either it will succeed or get rejected with a violation reason if it doesn't comply with the rules.
+
+*If you find any other tools that you would like to share please open a PR.*
+


### PR DESCRIPTION
## Changes
1. Updates doc for commit message standards
2. Includes sections on conventions and tools
3. Cleaned up the markdown with markdown linter

See result: https://github.com/amerikan/standards-and-practices/blob/main/standards/commits.md

## Purpose

To provide better information as to why good commit messages matter and also some tools that can help enforce a particular convention.

_If this closes an issue, name it here. If it doesn't, remove this line_

## Closes #276 
