### PR TITLE
docs(README.md): fixed typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 ## Code of Conduct
 
-1. No cussing, we're beyond that
-2. Keep the requests and issues professional and relevant to the work we're doing at Bitwise
+1. No cussing; we're beyond that.
+2. Keep the requests and issues professional and relevant to the work we're doing at Bitwise.
 3. Treat others with the same respect you would if you were talking to them in person. Don't be a jerk.
 4. Have fun and share your knowledge!
 
@@ -19,7 +19,7 @@
 
 ### Here's what we expect you to know _before_ you write any code:
 
-- Please read _all_ the links included
+- Please read _all_ the links included:
 
 #### Git
 
@@ -63,21 +63,21 @@
 - Open PowerShell with Administrator privileges. Run `Set-ExecutionPolicy RemoteSigned`. Type Y and press Enter to confirm that you want to make this change. (If you don't perform this step, you will not be able to run **any** PowerShell scripts on your system.)
 - Install the [Chocolatey package manager for Windows](https://chocolatey.org/install).
 - Reopen PowerShell with Administrator privileges, if necessary. Run the [install-apps-via-chocolatey.ps1](/best-practices/development-tools/windows-setup/install-apps-via-chocolatey.ps1) script to install a number of programs you will probably need. (Feel free to peek at this file's contents to see what it contains.)
-- (Optional) From the same PowerShell window, run the command `oosu10`. Here, you can easily configure a number of settings to have Windows respect your privacy a little more. Just make sure you understand what each setting does before you change it.
+- (Optional) From the same PowerShell window, run the command `oosu10`. Here, you can easily configure several settings to have Windows respect your privacy a little more. Just make sure you understand what each setting does before you change it.
 - After running `oosu10`, restart Windows (if applicable).
-- Install Android Studio.
+- Install Android Studio
 - Install the regular version of Visual Studio (as opposed to Visual Studio Code). Visual Studio Community Edition may be sufficient, or you may need a paid license for Visual Studio Professional, Enterprise, or similar. Either way, ask your PM (Project Manager).
 - You may wish to use the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/faq).
 - Ask your Project Manager if you need to install anything else.
 
 Using Chocolatey has several advantages:
 1. You can install most of the software you need just by running a single script.
-2. You can update all of this software later, by running `choco upgrade all`, as Administrator.
+2. You can update all of this software later; by running `choco upgrade all`; as Administrator.
 3. Chocolatey will automatically skip installing browser toolbars and junk like that.
 
 #### Account Setup
 
-#### You will need to schedule time with Greg Goforth, Corey Schuman, Chris Hawkins, or Jody Hicks to gain access to the following:
+#### You will need to schedule time with [Greg Goforth](mailto:ggoforth@bitwiseindustries.com), [Corey Schuman](mailto:cshuman@bitwiseindustries.com), [Chris Hawkins](mailto:chawkins@bitwiseindustries.com), or [Jody Hicks](mailto:jhicks@bitwiseindustries.com) to gain access to the following:
 
 ##### AWS Account:
 
@@ -87,8 +87,8 @@ Using Chocolatey has several advantages:
 
 ###### Meetings are now split into two types:
 
-- *[Presentations](presentations/README.md)*: Twice a month the software development teams in the Bitwise ecosystem meet on every other Wednesday from 4:00pm - 5:00pm PST to share their accomplishments, horror stories, workflow, and lessons learned with the rest of the BW community. While these meetings will generally be developer-focused, we invite anyone in the BW family to drop in and participate. You are highly encouraged to participate actively by leading a meeting on a topic of your choice. Ask [Elizabeth Eidelson](eeidelson@bitwiseindustries.com), [Sonia Rohani](nrohani@bitwiseindustries.com), or [Joel (Gyuhun Lee)](glee@bitwiseindustries.com) to add you to the GCal event so that you get reminders and emails.
-- *[Workshops](workshops/README.md)*: Once a month we will do a deep dive into a topic of interest for our workflow and/or processes. These will typically take longer than 1 hour, and will be a classroom/workshop setting. One developer will lead the workshop and the goal will be to produce developers who are proficient at a skill or process that will help us in our work.
+- *[Presentations](presentations/README.md)*: Twice a month the software development teams in the Bitwise ecosystem meet on every other Wednesday from 4:00 pm - 5:00 pm PST to share their accomplishments, horror stories, workflow, and lessons learned with the rest of the BW community. While these meetings will generally be developer-focused, we invite anyone in the BW family to drop in and participate. You are highly encouraged to participate actively by leading a meeting on a topic of your choice. Ask [Elizabeth Eidelson](mailto:eeidelson@bitwiseindustries.com), [Sonia Rohani](mailto:nrohani@bitwiseindustries.com), or [Joel (Gyuhun Lee)](mailto:glee@bitwiseindustries.com) to add you to the GCal event so that you get reminders and emails.
+- *[Workshops](workshops/README.md)*: Once a month we will do a deep dive into a topic of interest for our workflow and/or processes. These will typically take longer than 1 hour and will be a classroom/workshop setting. One developer will lead the workshop and the goal will be to produce, developers who are proficient at a skill or process that will help us in our work.
 
 ##### Frontend Masters:
 
@@ -103,15 +103,15 @@ Using Chocolatey has several advantages:
 - If your job entails design work, you will need to get access to the Bitwise Adobe Photoshop license.
 
 ## Need Help?
-Getting stuck is a natual part of development and happens to the best of us. It's better to reach out than to stay silent and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
+Getting stuck is a natural part of the development and happens to the best of us. It's better to reach out than to stay silent, and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
 
 ##### Slack channels:
-1. *bwtc-technical-discussions* - Great place for technical questions that involve some code. 
-2. *Your team channel* - When you start a project, you will be added to a private team channel. Feel free to ask your questions there! Your team lead may be able to help you through your blocker.
+1. **bwtc-technical-discussions** - Great place for technical questions that involve some code. 
+2. **Your team channel** - When you start a project, you will be added to a private team channel. Feel free to ask your questions there! Your team lead may be able to help you through your blocker.
 
 ## Contributing to Bitwise
 
-### You are expected to contribute _something_ to our processes. You can do this in many different ways, such as leading a BW Developer Connect meeting, writing up a markdown sheet for this repository on a topic you are passionate about, leading a workshop, or posting discussion topics in Bitwise's #shift-3-technical-discussions channel.
+#### You are expected to contribute _something_ to our processes. You can do this in many different ways, such as leading a BW Developer Connect meeting, writing up a markdown sheet for this repository on a topic you are passionate about, leading a workshop, or posting discussion topics in Bitwise's #shift-3-technical-discussions channel.
 
 #### [Click Here](/standards/contributing.md) to start contributing.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@
 
 Using Chocolatey has several advantages:
 1. You can install most of the software you need just by running a single script.
-2. You can update all of this software later; by running `choco upgrade all`; as Administrator.
+2. You can update all of this software later by running `choco upgrade all` as Administrator.
 3. Chocolatey will automatically skip installing browser toolbars and junk like that.
 
 #### Account Setup
@@ -88,7 +88,7 @@ Using Chocolatey has several advantages:
 ###### Meetings are now split into two types:
 
 - *[Presentations](presentations/README.md)*: Twice a month the software development teams in the Bitwise ecosystem meet on every other Wednesday from 4:00 pm - 5:00 pm PST to share their accomplishments, horror stories, workflow, and lessons learned with the rest of the BW community. While these meetings will generally be developer-focused, we invite anyone in the BW family to drop in and participate. You are highly encouraged to participate actively by leading a meeting on a topic of your choice. Ask [Elizabeth Eidelson](mailto:eeidelson@bitwiseindustries.com), [Sonia Rohani](mailto:nrohani@bitwiseindustries.com), or [Joel (Gyuhun Lee)](mailto:glee@bitwiseindustries.com) to add you to the GCal event so that you get reminders and emails.
-- *[Workshops](workshops/README.md)*: Once a month we will do a deep dive into a topic of interest for our workflow and/or processes. These will typically take longer than 1 hour and will be a classroom/workshop setting. One developer will lead the workshop and the goal will be to produce, developers who are proficient at a skill or process that will help us in our work.
+- *[Workshops](workshops/README.md)*: Once a month we will do a deep dive into a topic of interest for our workflow and/or processes. These will typically take longer than 1 hour and will be a classroom/workshop setting. One developer will lead the workshop and the goal will be to produce developers who are proficient at a skill or process that will help us in our work.
 
 ##### Frontend Masters:
 
@@ -106,7 +106,7 @@ Using Chocolatey has several advantages:
 Getting stuck is a natural part of the development and happens to the best of us. It's better to reach out than to stay silent, and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
 
 ##### Slack channels:
-1. **bwtc-technical-discussions** - Great place for technical questions that involve some code. 
+1. **bwtc-technical-discussions** - Great place for technical questions that involve some code.
 2. **Your team channel** - When you start a project, you will be added to a private team channel. Feel free to ask your questions there! Your team lead may be able to help you through your blocker.
 
 ## Contributing to Bitwise

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Using Chocolatey has several advantages:
 - If your job entails design work, you will need to get access to the Bitwise Adobe Photoshop license.
 
 ## Need Help?
-Getting stuck is a natural part of the development and happens to the best of us. It's better to reach out than to stay silent, and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
+Getting stuck is a natural part of development and happens to the best of us. It's better to reach out than to stay silent, and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
 
 ##### Slack channels:
 1. **bwtc-technical-discussions** - Great place for technical questions that involve some code.


### PR DESCRIPTION
## Changes
1. removed commas and added semicolons in areas that needed correction
2. Employees' names were not opening the default email. It was leading the user to a 404 error page when clicked on. Added `mailto:`

## Purpose
The purpose of this was to allow the user to open their default mail and message the person they have clicked on in the document. 

## Approach
Users wouldn't be redirected to a 404 error page.

## Learning
Learned more about markdown! I also got to use a plugin called Markdown Preview Enhanced to preview my markdown in visual studio code. 

I also wanted to know if shift3 workspace is still being used? The document states that we should be using it but we are using bitwiseindustries and also #shift-3-technical-discussions channel was rename to #bwtc-technical-discussions. Should that be updated as well?

### Closes #283 
