### PR TITLE
docs(standards): remove link to example project board

### DIFF
--- a/standards/project-setup.md
+++ b/standards/project-setup.md
@@ -16,7 +16,4 @@
   3. Open as many issues as you need to complete each epic.  
     Remember: follow Bitwise's [branching guide](branching.md) when you start working on these issues.
 
-### Example from Shift3:
-  [Sinclair Project Boards](https://github.com/Shift3/sinclair-scanner-application/projects)
-
 * This is your Project Manager's primary way of identifying your progress, so make sure check the automated progress and tweak anything that needs to be changed as the project progresses.


### PR DESCRIPTION
## Changes
1. Remove link to the project board given as an example

## Purpose
Removes a link that redirects to 404

Closes #285 
