### PR TITLE
docs(git-commands): Add switch and restore cmd descriptions

### DIFF
--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -1,22 +1,91 @@
 # Git Commands
+
 Git is a distributed version-control system for tracking changes in source code during software development. It is designed for coordinating work among programmers, but it can be used to track changes in any set of files. Its goals include speed, data integrity, and support for distributed, non-linear workflows.
 
 At Bitwise, we use git for a majority of our software projects.
 
 ## Bitwise Git specific resources
+
 1. [Commits](commits.md)
 2. [Branching](branching.md)
 3. [Code Versioning](code-versioning.md)
 
 ### Lesser known Git Commands
 
+#### Git Switch
+
+Git Official Documentation: https://git-scm.com/docs/git-switch
+
+Git Switch (and Restore) were added to address overloading of the `checkout` command, and to provide alternative (and clearer) ways to do some basic work.
+These commands do not provide new functionality, but may be easier to remember how to use them and what they do.
+
+Switch is useful to switch to another branch, creating a new branch in the process if desired.
+
+```shell
+$ git switch <branch-name>
+```
+
+can be used to switch to an existing branch instead of the checkout analog:
+
+```shell
+$ git checkout <branch-name>
+```
+
+For creating new branches, then switching to them, `switch -c` may seem more intuitive than `checkout -b`.
+
+```shell
+$ git switch -c <branch-name>
+```
+
+can be used to create a new branch and switch to it. Alternatively,
+
+```shell
+$ git checkout -b <branch-name>
+```
+
+provides identical functionality.
+
+#### Git Restore
+
+Git Official Documentation: https://git-scm.com/docs/git-restore
+
+Git Switch (and Restore) were added to address overloading of the `checkout` command, and to provide alternative (and clearer) ways to do some basic work.
+These commands do not provide new functionality, but may be easier to remember how to use them and what they do.
+
+Git Restore is useful to undo either changes made or changes staged.
+
+To undo changes made since the last commit (back to HEAD):
+
+```shell
+$ git restore <file-name>
+```
+
+If we wanted to restore the file to what it looked like say, two commits ago, we can use `--source` option and `HEAD~1` pointer:
+
+```text
+$ git restore --source HEAD~1 <file-name>
+```
+
+Commit hashes can also be used instead of the `HEAD~#` pointer for "time-travel" operations.
+
+Undoing staged files is another use for Restore. For instance, if we forgot to include a file in `.gitignore`, and we've staged the files for a commit, these can be unstaged prior to a commit in a relatively simple manner.
+
+To undo staged files (remove file entries from staging):
+
+```shell
+$ git restore --staged <file-name>
+```
+
+Git Status will inform us of the availability of the `restore` command when it will be useful.
+
 #### Git Stash
 
 Git Official Documentation: https://git-scm.com/docs/git-stash
 
-Git Stash is useful when you want to go back to a clean working directory but don't want to discard your current changes. It works by locally storing the current state of the working directory and index (the code within the current branch). In order to "stash" your code away for future use, first `git add` the files you want to stash away but *do not use git commit*. You use the `git stash push` command to create your stash. You can switch your branches and then apply the same code to the new branch with `git stash pop`. 
+Git Stash is useful when you want to go back to a clean working directory but don't want to discard your current changes. It works by locally storing the current state of the working directory and index (the code within the current branch). In order to "stash" your code away for future use, first `git add` the files you want to stash away but _do not use git commit_. You use the `git stash push` command to create your stash. You can switch your branches and then apply the same code to the new branch with `git stash pop`.
 
 In the below example, we are pushing this readme into our `foo-999-big-feature` branch which leaves us with a clean working directory/index within our original branch `mac-192-lesser-known-git`.
+
 ```shell
 $ git add standards/git-commands.md
 $ git stash push

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -65,7 +65,7 @@ If we wanted to restore the file to what it looked like say, two commits ago, we
 $ git restore --source HEAD~1 <file-name>
 ```
 
-Commit hashes can also be used instead of the `HEAD~#` pointer for "time-travel" operations.
+Commit hashes can also be used instead of the `HEAD~#` pointer for "rewind" operations. In this context, restore is "rewinding" one or more files to a previous point in those file(s) history. In this way, files can be worked on as if they hadn't undergone any changes since the given point in time (e.g.: point in time refers to a commit hash or HEAD pointer).
 
 Undoing staged files is another use for Restore. For instance, if we forgot to include a file in `.gitignore`, and we've staged the files for a commit, these can be unstaged prior to a commit in a relatively simple manner.
 

--- a/standards/git-commands.md
+++ b/standards/git-commands.md
@@ -12,12 +12,14 @@ At Bitwise, we use git for a majority of our software projects.
 
 ### Lesser known Git Commands
 
-#### Git Switch
-
-Git Official Documentation: https://git-scm.com/docs/git-switch
+### Switch & Restore
 
 Git Switch (and Restore) were added to address overloading of the `checkout` command, and to provide alternative (and clearer) ways to do some basic work.
 These commands do not provide new functionality, but may be easier to remember how to use them and what they do.
+
+#### Git Switch
+
+Git Official Documentation: https://git-scm.com/docs/git-switch
 
 Switch is useful to switch to another branch, creating a new branch in the process if desired.
 
@@ -48,9 +50,6 @@ provides identical functionality.
 #### Git Restore
 
 Git Official Documentation: https://git-scm.com/docs/git-restore
-
-Git Switch (and Restore) were added to address overloading of the `checkout` command, and to provide alternative (and clearer) ways to do some basic work.
-These commands do not provide new functionality, but may be easier to remember how to use them and what they do.
 
 Git Restore is useful to undo either changes made or changes staged.
 


### PR DESCRIPTION
## Changes
Adds two lesser known commands to appropriate section in git-commands
1. switch
2. restore

## Purpose
The checkout command is an overloaded workhorse and some of the functions are incredibly useful but not very intuitive to use and understand. This is why, in 2019, switch and restore were created in an effort to make using git more intuitive. These commands may be more accessible to newer git users.

## Learning
Links to official documentation provide more detail on the use of these commands:

https://git-scm.com/docs/git-switch
https://git-scm.com/docs/git-restore


Closes #287
