### PR TITLE
Update Epic Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic-issue-template.md
+++ b/.github/ISSUE_TEMPLATE/epic-issue-template.md
@@ -18,9 +18,9 @@ _Add a list of the steps required to implement this feature_
 
 ## Epic Checklist
 _Add a list of issues related to this epic_
-- [ ] Issue #997
-- [ ] Issue #998
-- [ ] Issue #999
+- [ ] #997
+- [ ] #998
+- [ ] #999
 
 ## Additional context
 _Add any other context or screenshots about the feature request here._


### PR DESCRIPTION
## Changes
1. Remove "Issue" prefix from listed issues

## Purpose
#289 

## Approach
GitHub has a new integration for linking issues that looks quite nice.  The "Issue" prefix is now unnecessary.
