### PR TITLE
fix(README): Shift3 should be bwtc

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Getting stuck is a natural part of development and happens to the best of us. It
 
 ## Contributing to Bitwise
 
-#### You are expected to contribute _something_ to our processes. You can do this in many different ways, such as leading a BW Developer Connect meeting, writing up a markdown sheet for this repository on a topic you are passionate about, leading a workshop, or posting discussion topics in Bitwise's #shift-3-technical-discussions channel.
+#### You are expected to contribute _something_ to our processes. You can do this in many different ways, such as leading a BW Developer Connect meeting, writing up a markdown sheet for this repository on a topic you are passionate about, leading a workshop, or posting discussion topics in Bitwise's #bwtc-technical-discussions channel.
 
 #### [Click Here](/standards/contributing.md) to start contributing.
 


### PR DESCRIPTION
## Changes
1. slack channel should be `#bwtc-technical-discussions`

## Purpose
 Shift3 slack channel no longer exists. We should replace any instance of it with the corrected slack channel.

## Approach
Replace with `#bwtc-technical-discussions`

Still finding these refs :smiley: 

Closes #251 
