### PR TITLE
fix(README): change shift3 reference to bwtc

### DIFF
--- a/standards/code-reviews.md
+++ b/standards/code-reviews.md
@@ -40,7 +40,7 @@
 
         * Automatic assignments balance the workload evenly across the whole team so everyone gets a chance to be a reviewer and a reviewee.
 
-        * Pending PR reviews show up on the #shift3-code-review Slack channel as a notification and reminder. This has helped us develop a quick turn-around on reviews.
+        * Pending PR reviews show up on the #bwtc-code-review Slack channel as a notification and reminder. This has helped us develop a quick turn-around on reviews.
 
     - Our standard code review process only requires a visual inspection of code. It is not necessary to pull down and run/test the code. That said, project teams can add their own functional review process within the team in addition to the standard cross-team visual review.
 


### PR DESCRIPTION
## Changes
Updates reference to Shift3 Slack channel to its new BWTC counterpart.

## Purpose
The Shift3 Slack channel mentioned no longer exists, but a new BWTC channel has been created that serves the same purpose.

## Approach
Replaced `#shift3-code-review` with `#bwtc-code-review`.

Closes #251 
