### PR TITLE
docs(editorconfig): Add EditorConfig documentation and example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 #### Project Setup
 - [Using Github Projects](/standards/project-setup.md) to communicate progress
 - [Readme Guidelines](/standards/readme-guidelines.md) to document projects
-- [EditorConfig](/standards/editorconfig.md) to help with consistent code style
+- [EditorConfig](/best-practices/development-tools/editorconfig.md) to help with consistent code style
 
 #### Code Review
 

--- a/best-practices/development-tools/editorconfig.md
+++ b/best-practices/development-tools/editorconfig.md
@@ -4,7 +4,7 @@
 
 ## Editor & IDE Support
 
-Check [editorconfig.org](https://editorconfig.org/) to see if your text editor or IDE has [built-in support](https://editorconfig.org/#pre-installed) or [requires a plugin](https://editorconfig.org/#download). For convenience, here are some shortcuts for commonly-used editors used by BWTC developers:
+Check [editorconfig.org](https://editorconfig.org/) to see if your text editor or IDE has [built-in support](https://editorconfig.org/#pre-installed) or [requires a plugin](https://editorconfig.org/#download). For convenience, here are some shortcuts to plugins for some commonly-used editors:
 
 * [Atom](https://github.com/sindresorhus/atom-editorconfig#readme)
 * [Emacs](https://github.com/editorconfig/editorconfig-emacs#readme)
@@ -14,9 +14,10 @@ Check [editorconfig.org](https://editorconfig.org/) to see if your text editor o
 
 ## Sample .editorconfig
 
-Here's a sample `.editorconfig` that can be dropped into your projects. The EditorConfig wiki includes a [complete list of properties](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties).
+Here's a sample `.editorconfig` that can be dropped into your projects. The EditorConfig wiki includes a [complete list of properties](https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties) that you can use to customize your specific project.
 
 ```
+# EditorConfig is awesome:
 # http://editorconfig.org
 
 root = true
@@ -24,11 +25,18 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-indent_style = space
 indent_size = 4
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+[*.html]
+indent_size = 2
+
 [*.{js,jsx}]
 indent_size = 2
+
+[*.md]
+max_line_length = off
+trim_trailing_whitespace = false
 ```


### PR DESCRIPTION
## Changes

1. Add docs for EditorConfig to the best-practices directory.
2. Add link to EditorConfig docs to the Project Setup section of the S&P README.

## Purpose

I'm a big fan of consistent code styling, and an even bigger fan of automating that process as much as possible. This is one step to help us do ... that.

## Approach

By adding this to the S&P docs, we can start getting BWTC devs to add `.editorconfig` files to their projects. Many of them are [already doing so](https://github.com/search?q=org%3AShift3+editorconfig&type=code), but this helps set it as a standard.

## Pre-Testing TODOs

N/A

## Testing Steps

N/A

## Learning

Main website:
https://editorconfig.org/

Examples we can pull from:
https://github.com/editorconfig/editorconfig/wiki/Projects-Using-EditorConfig

Properties we can set:
https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties

Closes #307.
