### PR TITLE
doc(readme): Developers should know about our stack overflow account

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Getting stuck is a natural part of development and happens to the best of us. It
 
 1. **Your team channel** - When you start a project, you will be added to a private team channel. Feel free to ask your questions there! Your team lead may be able to help you through your blocker.
 2. **[bwtc-stackoverflow](https://stackoverflow.com/c/bwtc/questions)** - Did you know we have our own Stack Overflow? Take a look, it has some great quesions and answers. 
-3. **bwtc-technical-discussions** - Great place for technical questions that involve some code.
+3. **[bwtc-technical-discussions](https://bitwiseindustries.slack.com/archives/CN462BE5D)** - Great place for technical questions that involve some code.
 ## Contributing to Bitwise
 
 #### You are expected to contribute _something_ to our processes. You can do this in many different ways, such as leading a BW Developer Connect meeting, writing up a markdown sheet for this repository on a topic you are passionate about, leading a workshop, or posting discussion topics in Bitwise's #bwtc-technical-discussions channel.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Using Chocolatey has several advantages:
 ## Need Help?
 Getting stuck is a natural part of development and happens to the best of us. It's better to reach out than to stay silent, and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
 
-##### Slack channels:
+##### Communication Channels:
 
 
 1. **Your team channel** - When you start a project, you will be added to a private team channel. Feel free to ask your questions there! Your team lead may be able to help you through your blocker.

--- a/README.md
+++ b/README.md
@@ -111,9 +111,11 @@ Using Chocolatey has several advantages:
 Getting stuck is a natural part of development and happens to the best of us. It's better to reach out than to stay silent, and we encourage you to do so. If you find yourself stuck on a task for more than 45 minutes, here are a couple of places to get help:
 
 ##### Slack channels:
-1. **bwtc-technical-discussions** - Great place for technical questions that involve some code.
-2. **Your team channel** - When you start a project, you will be added to a private team channel. Feel free to ask your questions there! Your team lead may be able to help you through your blocker.
 
+
+1. **Your team channel** - When you start a project, you will be added to a private team channel. Feel free to ask your questions there! Your team lead may be able to help you through your blocker.
+2. **[bwtc-stackoverflow](https://stackoverflow.com/c/bwtc/questions)** - Did you know we have our own Stack Overflow? Take a look, it has some great quesions and answers. 
+3. **bwtc-technical-discussions** - Great place for technical questions that involve some code.
 ## Contributing to Bitwise
 
 #### You are expected to contribute _something_ to our processes. You can do this in many different ways, such as leading a BW Developer Connect meeting, writing up a markdown sheet for this repository on a topic you are passionate about, leading a workshop, or posting discussion topics in Bitwise's #bwtc-technical-discussions channel.


### PR DESCRIPTION
## Changes
1. Modified "Need Help" section within the S&P repo to have links to resources.
2. Our specific stack overflow instance is now referenced within the "Need Help" section.

## Purpose
One of the pain points we have as an organization is not archiving questions and discussions within slack. 

## Approach
Stack Overflow has traditionally been a resource developers go to for longstanding and specific issues.

Closes #332 
