### PR TITLE
fix(README): Differentiate between BW Handbook/BWTC Guidebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 ### Here's what we expect you to know _before_ you write any code:
 
 - Please read _all_ the links included:
-- Take a look at [our **Handbook**](https://bwtc-handbook.notion.site/BWTC-Handbook-71256770d53f46439aecd989b07d1533) for all your (mostly) non-code related needs!
+- Take a look at [our **Guidebook**](https://bwtc-handbook.notion.site/BWTC-Handbook-71256770d53f46439aecd989b07d1533) for all your (mostly) non-code related needs!
 
 #### Git
 


### PR DESCRIPTION
## Changes
1. Change Guidebook and Handbook for a bit more differentiation. 
2. Item 2

## Purpose
Differentiate between BW Handbook/BWTC Guidebook

## Approach
Changes the text but keep the url the same.

Closes #337
