### PR TITLE
Fix: Titles should start with uppercase

### DIFF
--- a/best-practices/client-side/framework/angular/README.md
+++ b/best-practices/client-side/framework/angular/README.md
@@ -1,6 +1,6 @@
-# angular
+# Angular
 
-## this could be separated by version type in the future, how to spin up a boilerplate
+## This could be separated by version type in the future, how to spin up a boilerplate
 
 ## CircleCI
 * Official Resource : https://angular.io/guide/testing#configure-project-for-circle-ci


### PR DESCRIPTION
## Changes
_List Changes Introduced by this PR_
Update all the titles that start with lowercase.


## Purpose
 Some titles within a file started with a lowercase

## Approach
 Replace all the titles that start with lowercase to uppercase.


Closes #348
