### PR TITLE
feat(#369, code-reviews): Add additional resource links

### DIFF
--- a/standards/code-reviews.md
+++ b/standards/code-reviews.md
@@ -89,6 +89,6 @@ Remember, this is a standard, so it isn't optional. _Never_ close your own Pull 
 
 [Digital Ocean's Effective Code Review Tips](https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/)
 
-[Corey Shuman's Dev Connect on Code Review](https://playback.lifesize.com/#/publicvideo/9a9229d2-22b1-40db-9e8e-26308225128d?vcpubtoken=910e3bbe-cc9e-489d-b844-afe87baaccaa/)
+[Corey Shuman's Dev Connect on Code Review](https://playback.lifesize.com/#/publicvideo/9a9229d2-22b1-40db-9e8e-26308225128d?vcpubtoken=910e3bbe-cc9e-489d-b844-afe87baaccaa)
 
-[Google 'Speed of Code Reviews' Article](https://google.github.io/eng-practices/review/reviewer/speed.html/)
+[Google 'Speed of Code Reviews' Article](https://google.github.io/eng-practices/review/reviewer/speed.html)

--- a/standards/code-reviews.md
+++ b/standards/code-reviews.md
@@ -88,3 +88,7 @@ Remember, this is a standard, so it isn't optional. _Never_ close your own Pull 
 [How to become a better code reviewer](https://blog.asana.com/2016/12/7-ways-to-uplevel-your-code-review-skills/)
 
 [Digital Ocean's Effective Code Review Tips](https://blog.digitalocean.com/how-to-conduct-effective-code-reviews/)
+
+[Corey Shuman's Dev Connect on Code Review](https://playback.lifesize.com/#/publicvideo/9a9229d2-22b1-40db-9e8e-26308225128d?vcpubtoken=910e3bbe-cc9e-489d-b844-afe87baaccaa/)
+
+[Google 'Speed of Code Reviews' Article](https://google.github.io/eng-practices/review/reviewer/speed.html/)


### PR DESCRIPTION
## Changes
1. add link to BWTC dev connect on code review
2. add link to Google article emphasizing code review speed

## Purpose
#369 
This pr adds links to the resources section of the code review page. Applicable outside information was found that could be considered supplemental to our standards for code review, and find a good place here.  

## Approach
Additional links and resources bolster the strength of our standards, provided that the organization agrees with them.  

## Pre-Testing TODOs
NA

## Testing Steps
View the links and assess their value in including them in our S&P repo.

## Learning
Learning to navigate through the S&P and find places where I can contribute was the majority of this feature, and I'm looking forward to additional contributions I can make. 

Closes #369