### PR TITLE
chore(standards): find and change web links to relative links

### DIFF
--- a/standards/contributing-outside-organization.md
+++ b/standards/contributing-outside-organization.md
@@ -115,4 +115,4 @@ branch in the repository.
 ### Client commits
 
 We strongly recommend the client use the same commit message convention as Bitwise. This is detailed
-in the Shift3 Standards & Practice repository, available [here](https://github.com/Shift3/standards-and-practices/blob/master/standards/commits.md#shift3s-convention-for-how-to-structure-write-and-use-your-commits)
+in the Shift3 Standards & Practice repository, available [here](./commits.md#shift3s-convention-for-how-to-structure-write-and-use-your-commits)

--- a/standards/developer-accountability.md
+++ b/standards/developer-accountability.md
@@ -8,8 +8,8 @@ If you have any questions, comments or concerns, do not hesitate to reach out to
 
 
 ## Accountability Checklist
-- [ ] **Github project boards need to be setup according to [S&P guidelines](https://github.com/Shift3/standards-and-practices/blob/main/standards/project-setup.md)**
-- [ ] **Assign [@Shift3/pr-team](https://github.com/orgs/Shift3/teams/pr-team) to your pull requests, per our [code review](https://github.com/Shift3/standards-and-practices/blob/main/standards/code-reviews.md#process) process**
+- [ ] **Github project boards need to be setup according to [S&P guidelines](./project-setup.md)**
+- [ ] **Assign [@Shift3/pr-team](https://github.com/orgs/Shift3/teams/pr-team) to your pull requests, per our [code review](./code-reviews.md#process) process**
 - [ ] **Assign pull requests to [@Shift3/pr-team](https://github.com/orgs/Shift3/teams/pr-team) in addition to the developers on your project**
 
     Assigning a pull request to @shift3/pr-team will automatically assign three developers from the pull request team and assign them to perform a review.
@@ -33,7 +33,7 @@ If you have any questions, comments or concerns, do not hesitate to reach out to
 
     On rare occasions, when a pull request creator could not find a reviewer within the 24 hour window, the pull request creator should ping @here in #bwtc-code-review slack channel for assistance.
 
-- [ ] **Format of GIT commit messages and title follow [Karma Commit standards](https://github.com/Shift3/standards-and-practices/blob/main/standards/commits.md#git-commit-messages).**
+- [ ] **Format of GIT commit messages and title follow [Karma Commit standards](./commits.md#git-commit-messages).**
 
     Example: `fix(login-screen): logo should display correctly`
 
@@ -45,7 +45,7 @@ If you have any questions, comments or concerns, do not hesitate to reach out to
     Example: `mac-999-fixes-deploys`
 
 
-    For additional information, refer to the docs [here](https://github.com/Shift3/standards-and-practices/blob/main/standards/branching.md). 
+    For additional information, refer to the docs [here](./branching.md). 
 
 - [ ] **Pull request always reference an issue number in the description section**
 
@@ -55,7 +55,7 @@ If you have any questions, comments or concerns, do not hesitate to reach out to
     Example: `Closes #999`
 
 
-    For additional information, refer to our [Pull Request template](https://github.com/Shift3/standards-and-practices/blob/main/standards/pull-request-template.md). 
+    For additional information, refer to our [Pull Request template](./pull-request-template.md). 
 
 - [ ] **Project source code include our Issue and Pull Request Templates**
 
@@ -64,11 +64,11 @@ If you have any questions, comments or concerns, do not hesitate to reach out to
 
     For additional information, refer to the docs [here](https://github.com/Shift3/standards-and-practices/tree/main/.github ).
 
-- [ ] **[Review comments](https://github.com/Shift3/standards-and-practices/blob/main/standards/code-reviews.md#reviewer) be clear and constructive**
+- [ ] **[Review comments](./code-reviews.md#reviewer) be clear and constructive**
 
     Try to always provide meaningful feedback in your review, which could also include complimenting the work or pointing out something you learned or were impressed with. We would like to avoid “rubber stamping” or “looks good to me” types of reviews which don’t provide an opportunity for growth and improvement.
 
-- [ ]  Create **[Release tag and branch](https://github.com/Shift3/standards-and-practices/blob/main/standards/code-versioning.md) on each application release**
+- [ ]  Create **[Release tag and branch](./code-versioning.md) on each application release**
 
 A pull request reviewer is our first line of defense for improving software quality and avoiding defects. Reviewers are encouraged to refer and cite these standards when they believe standards are not being adhered to during their review. However, reviewers should not block any pull request simply because of non-adherence. A reviewer should take into consideration what is and is not considered a blocking event. Here are some guidelines on the topic of blocking and non-blocking events:
 

--- a/standards/issue-template.md
+++ b/standards/issue-template.md
@@ -10,7 +10,7 @@ Follow the [step by step guide](https://help.github.com/en/github/building-a-str
 1. Go to your repository's `Settings` tab.
 2. Under the `Options` section, scroll down to **Features**.
 3. Make sure **Issues** option is selected (check the box) and click the `Set up templates` button.
-4. Select which type of template you want to set up. Github has pre-configured templates that you can choose to use. You can edit the default templates if you need to, or you can add a custom template manually. We have two issue templates in this repository for [Feature Request](https://github.com/Shift3/standards-and-practices/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml) and [Bug Reports](https://github.com/Shift3/standards-and-practices/blob/main/.github/ISSUE_TEMPLATE/bug_report.md) that are a good starting point.
+4. Select which type of template you want to set up. Github has pre-configured templates that you can choose to use. You can edit the default templates if you need to, or you can add a custom template manually. We have two issue templates in this repository for [Feature Request](https://github.com/Shift3/standards-and-practices/blob/main/.github/ISSUE_TEMPLATE/feature_request.yml) and [Bug Reports](/.github/ISSUE_TEMPLATE/bug_report.md) that are a good starting point.
 5. Once you are happy with the template, click on the green `Propose changes` button at the top right of the page.
 6. Fill out the commit information that pops up. Choose the option to create a new branch and start a pull request rather than committing directly to your default branch.
 7. Have your team review and approve your pull request. Once it is closed, you will have issue templates.


### PR DESCRIPTION
a handful of links to other markdown files were linked https://github... This works fine on GitHub but not in VS Code nor is it consistent Changed all possible outliers to ./*.md

## Changes
1. Links to local markdown files changed from external(https://...) to local(./...)

## Purpose
The links were difficult to navigate in VS Code and inconsistent with a majority of absolute or relative paths

## Approach
Using relative paths to replace links found only inside standards

## Pre-Testing TODOs
- [] Right click and preview relevant files

## Testing Steps
Click on relevant links, observe navigation within preview

## Learning
Didn't know you could link .md files and navigate them in this fashion
