### PR TITLE
fix(dependabot): Update dependencies automatically monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
## Changes
1. Make dependabot only look at updates once a month and only on the main branch. 

## Purpose
Most of the gems we use do not need to be updated more than once a month. We were getting bombarded with dependabot updates and we only use one library for checking urls. There is not a huge attack vector on our ci/cd jobs.

## Approach
Make dependabot check and auto update every month. 

Closes #317
